### PR TITLE
Only critical VPC networks must log DNS in GCP

### DIFF
--- a/Cloud App and Config Profile/Cloud App and Config Test Guide.md
+++ b/Cloud App and Config Profile/Cloud App and Config Test Guide.md
@@ -5726,8 +5726,7 @@ gcloud dns policies list --flatten="networks[]" --format="table[box,title='All D
 Each VPC Network should be associated with a DNS policy with logging enabled.
 
 **Verification**
-
-Evidence or test output indicates that cloud DNS logging is enabled for all VPC networks.
+ Evidence or test output indicates that cloud DNS logging is enabled for all critical VPC networks, meaning any VPC network that is used to process confidential data.
 
 
 ---


### PR DESCRIPTION
In the cloud subgroup, our consensus was to contrain this VPC DNS logging requirement only to critical VPCs, which we define as those used to process confidential data (e.g., PII). This constraint was missing from the test guide.