### PR TITLE
Adding acknowledgments section to all three profiles

### DIFF
--- a/Cloud App and Config Profile/Cloud App and Config Specification.md
+++ b/Cloud App and Config Profile/Cloud App and Config Specification.md
@@ -3,8 +3,20 @@
 
 Version 0.5 - April 8, 2024
 
+# Contributors
+The App Defense Alliance Application Security Assessment Working Group (ASA WG) would like to thank the following individuals for their contributions to this specification:
 
-
+* Alex Duff (ASA WG Chair)
+* Brooke Davis (ASA WG Vice Chair)
+* Brad Ree
+* Cody Martin
+* Juan Manuel Martinez Hernandez
+* Julia McLaughlin
+* Rennie deGraaf
+* Rupesh Nair
+* Soledad Antelada Toledano
+* Tony Balkan
+* Viktor Sytnik
 
 # Table of Contents
 

--- a/Mobile App Profile/Mobile App Specification.md
+++ b/Mobile App Profile/Mobile App Specification.md
@@ -51,6 +51,7 @@ The App Defense Alliance Application Security Assessment Working Group (ASA WG) 
 * Juan Manuel Martinez Hernandez
 * Jullian Gerhart
 * Olivier Tuchon
+* Peter Mueller
 * Rupesh Nair
 * Syrone Hanks II
 * Thomas Cannon

--- a/Mobile App Profile/Mobile App Specification.md
+++ b/Mobile App Profile/Mobile App Specification.md
@@ -52,6 +52,7 @@ The App Defense Alliance Application Security Assessment Working Group (ASA WG) 
 * Jullian Gerhart
 * Olivier Tuchon
 * Peter Mueller
+* Riccardo Poffo
 * Rupesh Nair
 * Syrone Hanks II
 * Thomas Cannon

--- a/Mobile App Profile/Mobile App Specification.md
+++ b/Mobile App Profile/Mobile App Specification.md
@@ -34,7 +34,28 @@ Version 0.7 - June 14, 2024
   </tr>
 </table>
 
+# Contributors
+The App Defense Alliance Application Security Assessment Working Group (ASA WG) would like to thank the following individuals for their contributions to this specification:
 
+* Alex Duff (ASA WG Chair)
+* Brooke Davis (ASA WG Vice Chair)
+* Anna Bhirud
+* Antonio Nappa
+* Brad Ree
+* Cody Martin
+* Corey Gagnon
+* Eugene Liderman
+* Joel Scambray
+* Jorge Damian
+* José María Santos López
+* Juan Manuel Martinez Hernandez
+* Jullian Gerhart
+* Olivier Tuchon
+* Rupesh Nair
+* Syrone Hanks II
+* Thomas Cannon
+* Tim Bolton
+* Yiannis Kozyrakis
 
 # **Table of Contents**
 

--- a/Web App Profile/Web App Specification.md
+++ b/Web App Profile/Web App Specification.md
@@ -8,6 +8,22 @@ Version 0.7 - May 25, 2024
 | 0.5 | 5/25/24 | Initial draft based on Web App Tiger Team review of ASVS specification |
 | 0.7 | 5/25/24 | Updates from Tiger Team review of 0.5 spec |
 
+# Contributors
+The App Defense Alliance Application Security Assessment Working Group (ASA WG) would like to thank the following individuals for their contributions to this specification:
+
+* Alex Duff (ASA WG Chair)
+* Brooke Davis (ASA WG Vice Chair)
+* Brad Ree
+* Chilik Tamir
+* Christopher Estrada
+* Cody Martin
+* Gianluca Braga
+* John Tidwell
+* Juan Manuel Martinez Hernandez
+* Jullian Gerhart
+* Michael Whiteman
+* Viktor Sytnik
+* Zach Moreno
 
 # Table of Contents
 1 [Authentication](#1-authentication)


### PR DESCRIPTION
Extracted a list of all editors of earlier working documents and listed those individuals in an acknowledgements section at the top of the cloud, web, and mobile specification documents. Note that this is an incomplete list of all participants in the working sessions so some contributors may unfortunately be omitted.