### PR TITLE
 Updating links in TOC and formatting

### DIFF
--- a/Mobile App Profile/Mobile App Specification.md
+++ b/Mobile App Profile/Mobile App Specification.md
@@ -1,40 +1,29 @@
 
-# **App Defense Alliance Mobile Application Specification**
+# App Defense Alliance Mobile Application Specification
 
 Version 0.7 - June 14, 2024
 
-
-# **Revision History**
-
+## Revision History
 
 <table>
   <tr>
-   <td><strong>Version</strong>
-   </td>
-   <td><strong>Date</strong>
-   </td>
-   <td><strong>Description</strong>
-   </td>
+   <td><strong>Version</strong></td>
+   <td><strong>Date</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>0.5
-   </td>
-   <td>5/10/24
-   </td>
-   <td>Initial draft based on Mobile App Tiger Team review of MASVS specification
-   </td>
+   <td>0.5</td>
+   <td>5/10/24</td>
+   <td>Initial draft based on Mobile App Tiger Team review of MASVS specification</td>
   </tr>
   <tr>
-   <td style="background-color: #f3f3f3">0/7
-   </td>
-   <td style="background-color: #f3f3f3">5/25/24
-   </td>
-   <td style="background-color: #f3f3f3">Updates from TIger Team review of 0.5 spec
-   </td>
+   <td>0.7</td>
+   <td>5/25/24</td>
+   <td>Updates from Tiger Team review of 0.5 spec</td>
   </tr>
 </table>
 
-# Contributors
+## Contributors
 The App Defense Alliance Application Security Assessment Working Group (ASA WG) would like to thank the following individuals for their contributions to this specification:
 
 * Alex Duff (ASA WG Chair)
@@ -59,814 +48,589 @@ The App Defense Alliance Application Security Assessment Working Group (ASA WG) 
 * Tim Bolton
 * Yiannis Kozyrakis
 
-# **Table of Contents**
-
-**Android**
-
-1.1 [Storage](https://mas.owasp.org/MASVS/05-MASVS-STORAGE/)
-
-1.1.1 [The app security stores sensitive data](https://mas.owasp.org/MASVS/controls/MASVS-STORAGE-1/)
-
-1.1.2 [The app prevents leakage of sensitive data](https://mas.owasp.org/MASVS/controls/MASVS-STORAGE-2/)
-
-1.2 [Crypto](https://mas.owasp.org/MASVS/06-MASVS-CRYPTO/)
-
-1.2.1 [The app employs strong cryptography and uses it according to industry best practices](https://mas.owasp.org/MASVS/controls/MASVS-CRYPTO-1/)
-
-1.2.2 [The app performs key management according to industry best practices](https://mas.owasp.org/MASVS/controls/MASVS-CRYPTO-2/)
-
-1.3 [Auth](https://mas.owasp.org/MASVS/07-MASVS-AUTH/)
-
-1.3.1 [The app uses secure authentication and authorization protocols and follows the relevant best practices](https://mas.owasp.org/MASVS/controls/MASVS-AUTH-1/)
-
-1.4 [Network](https://mas.owasp.org/MASVS/08-MASVS-NETWORK/)
-
-1.4.1 [The app secures all network traffic according to the current best practices](https://mas.owasp.org/MASVS/controls/MASVS-NETWORK-1/)
-
-1.5 [Platform](https://mas.owasp.org/MASVS/09-MASVS-PLATFORM/)
-
-1.5.1 [The app uses IPC mechanisms securely](https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-1/)
-
-1.5.2 [The app uses WebViews securely](https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-2/)
-
-1.5.3 [The app uses the user interface securely](https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-3/)
-
-1.6 [Code](https://mas.owasp.org/MASVS/10-MASVS-CODE/)
-
-1.6.1 [The app requires an up-to-date platform version](https://mas.owasp.org/MASVS/controls/MASVS-CODE-1/)
-
-1.6.2 [The app only uses software components without known vulnerabilities](https://mas.owasp.org/MASVS/controls/MASVS-CODE-3/)
-
-1.6.3 [The app validates and sanitizes all untrusted inputs](https://mas.owasp.org/MASVS/controls/MASVS-CODE-4/)
-
-1.7 [Resilience](https://mas.owasp.org/MASVS/11-MASVS-RESILIENCE/)
-
-1.7.1 [The app implements anti-tampering mechanisms](https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-2/)
-
-1.7.2 [The app implements anti-static analysis mechanisms](https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-3/)
-
-1.7.3 [The app implements anti-dynamic analysis techniques](https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-4/)
-
-1.8 [Privacy](https://mas.owasp.org/MASVS/12-MASVS-PRIVACY/)
-
-1.8.1 [The app minimizes access to sensitive data and resources](https://mas.owasp.org/MASVS/controls/MASVS-PRIVACY-1/)
-
-1.8.2 [The app is transparent about data collection and usage](https://mas.owasp.org/MASVS/controls/MASVS-PRIVACY-3/)
-
-1.8.3 [The app offers user control over their data](https://mas.owasp.org/MASVS/controls/MASVS-PRIVACY-4/)
-
-**iOS**
-
-2.1 [Storage](https://mas.owasp.org/MASVS/05-MASVS-STORAGE/)
-
-2.1.1 [The app security stores sensitive data](https://mas.owasp.org/MASVS/controls/MASVS-STORAGE-1/)
-
-2.1.2 [The app prevents leakage of sensitive data](https://mas.owasp.org/MASVS/controls/MASVS-STORAGE-2/)
-
-2.2 [Crypto](https://mas.owasp.org/MASVS/06-MASVS-CRYPTO/)
-
-2.2.1 [The app employs strong cryptography and uses it according to industry best practices](https://mas.owasp.org/MASVS/controls/MASVS-CRYPTO-1/)
-
-2.2.2 [The app performs key management according to industry best practices](https://mas.owasp.org/MASVS/controls/MASVS-CRYPTO-2/)
-
-2.3 [Auth](https://mas.owasp.org/MASVS/07-MASVS-AUTH/)
-
-2.3.1 [The app uses secure authentication and authorization protocols and follows the relevant best practices](https://mas.owasp.org/MASVS/controls/MASVS-AUTH-1/)
-
-2.4 [Network](https://mas.owasp.org/MASVS/08-MASVS-NETWORK/)
-
-2.4.1 [The app secures all network traffic according to the current best practices](https://mas.owasp.org/MASVS/controls/MASVS-NETWORK-1/)
-
-2.5 [Platform](https://mas.owasp.org/MASVS/09-MASVS-PLATFORM/)
-
-2.5.1 [The app uses IPC mechanisms securely](https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-1/)
-
-2.5.2 [The app uses WebViews securely](https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-2/)
-
-2.5.3 [The app uses the user interface securely](https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-3/)
-
-2.6 [Code](https://mas.owasp.org/MASVS/10-MASVS-CODE/)
-
-2.6.1 [The app requires an up-to-date platform version](https://mas.owasp.org/MASVS/controls/MASVS-CODE-1/)
-
-2.6.2 [The app only uses software components without known vulnerabilities](https://mas.owasp.org/MASVS/controls/MASVS-CODE-3/)
-
-2.6.3 [The app validates and sanitizes all untrusted inputs](https://mas.owasp.org/MASVS/controls/MASVS-CODE-4/)
-
-2.7 [Resilience](https://mas.owasp.org/MASVS/11-MASVS-RESILIENCE/)
-
-2.7.1 [The app implements anti-tampering mechanisms](https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-2/)
-
-2.7.2 [The app implements anti-static analysis mechanisms](https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-3/)
-
-2.7.3 [The app implements anti-dynamic analysis techniques](https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-4/)
-
-2.8 [Privacy](https://mas.owasp.org/MASVS/12-MASVS-PRIVACY/)
-
-2.8.1 [The app minimizes access to sensitive data and resources](https://mas.owasp.org/MASVS/controls/MASVS-PRIVACY-1/)
-
-2.8.2 [The app is transparent about data collection and usage](https://mas.owasp.org/MASVS/controls/MASVS-PRIVACY-3/)
-
-2.8.3 [The app offers user control over their data](https://mas.owasp.org/MASVS/controls/MASVS-PRIVACY-4/)
-
-**Introduction**
+## Introduction
 
 In today’s digitally-driven world, mobile applications are the backbone of countless businesses and organizations. Unfortunately, they are also prime targets for cyberattacks that threaten data confidentiality, service availability, and overall business integrity. To mitigate risks and build a secure mobile environment, a robust mobile application security standard and certification program is essential.
 
-**Our Approach: OWASP MASVS as the Foundation**
+### Our Approach: OWASP MASVS as the Foundation
 
 This program leverages the internationally recognized OWASP Mobile Application Security Verification Standard (MASVS) as its core. The OWASP MASVS offers a comprehensive set of security assessment requirements and guidelines covering the entire mobile application development lifecycle. Building upon this base, the App Defense Alliance (ADA) focused on testable requirements with clear acceptance criteria. Further, the ADA approach emphasizes the use of automation where possible.
 
 
-# **Applicability**
+### Applicability
 
 This document is intended for system and application administrators, security specialists, auditors, help desk, platform deployment, and/or DevOps personnel who plan to develop, deploy, assess, or secure mobile applications.
 
 
-# **References**
-
-
+### References
 
 1. [OWASP Mobile Application Security Verification Standard](https://github.com/OWASP/owasp-masvs/)
 
 
-# **Licensing**
+### Licensing
 
 This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License.](https://creativecommons.org/licenses/by-sa/4.0/)
 
 
-# **Assumptions**
+### Assumptions
 
-The following assumptions are intended to aid the Authorized Labs for baseline security testing. 
+The following assumptions are intended to aid the Authorized Labs for baseline security testing.
 
-**PLATFORM**
+#### PLATFORM
 
 The mobile application relies upon a trustworthy computing platform that runs a recent version of a mobile operating system (i.e. N-2) from the date of evaluation.   For the purposes of this document, N refers to a major operation system release.
 
-**PROPER_USER**
+#### PROPER_USER
 
 The user of the application software is not willfully negligent or hostile, and sets a device PIN/Passcode.
 
-**SENSITIVE_DATA**
+#### SENSITIVE_DATA
 
 Data that is of particular concern from a security perspective, including personal identifiable information, credentials, and keys. This is not taking into account regulatory requirements for privacy or compliance for various verticals such as healthcare or finance.
 
 PII is any information that can be used to directly or indirectly identify a specific individual. This data, if mishandled, can lead to harm, discrimination, or privacy violations.
 
-**TOOLING**
+#### TOOLING
 
 The ADA approach emphasizes the use of automation where possible. We expect future tooling investment to assist with gathering of developer evidence for Level 1 assurance.
 
+# Table of Contents
+- [1 ANDROID](#1-android)
+  - [1.1 Storage](#11-storage)
+    - [1.1.1 The app shall securely store sensitive data](#111-the-app-shall-securely-store-sensitive-data)
+    - [1.1.2 The app prevents leakage of sensitive data](#112-the-app-prevents-leakage-of-sensitive-data)
+  - [1.2 Crypto](#12-crypto)
+    - [1.2.1 The app employs current strong cryptography and uses it according to industry best practices.](#121-the-app-employs-current-strong-cryptography-and-uses-it-according-to-industry-best-practices)
+    - [1.2.2 The app performs key management according to industry best practices.](#122-the-app-performs-key-management-according-to-industry-best-practices)
+  - [1.3 Auth](#13-auth)
+    - [1.3.1 The app uses secure authentication and authorization protocols and follows the relevant best practices.](#131-the-app-uses-secure-authentication-and-authorization-protocols-and-follows-the-relevant-best-practices)
+  - [1.4 Network](#14-network)
+    - [1.4.1 The app secures all network traffic according to the current best practices.](#141-the-app-secures-all-network-traffic-according-to-the-current-best-practices)
+  - [1.5 Platform](#15-platform)
+    - [1.5.1 The app uses IPC mechanisms securely.](#151-the-app-uses-ipc-mechanisms-securely)
+    - [1.5.2 The app uses WebViews securely.](#152-the-app-uses-webviews-securely)
+    - [1.5.3 The app uses the user interface securely.](#153-the-app-uses-the-user-interface-securely)
+  - [1.6 Code](#16-code)
+    - [1.6.1 The app requires an up-to-date platform version.](#161-the-app-requires-an-up-to-date-platform-version)
+    - [1.6.2 The app only uses software components without known vulnerabilities.](#162-the-app-only-uses-software-components-without-known-vulnerabilities)
+    - [1.6.3 The app validates and sanitizes all untrusted inputs.](#163-the-app-validates-and-sanitizes-all-untrusted-inputs)
+  - [1.7 Resilience](#17-resilience)
+    - [1.7.1 The app implements anti-tampering mechanisms.](#171-the-app-implements-anti-tampering-mechanisms)
+    - [1.7.2 The app implements anti-static analysis mechanisms](#172-the-app-implements-anti-static-analysis-mechanisms)
+    - [1.7.3 The app implements anti-dynamic analysis mechanisms](#173-the-app-implements-anti-dynamic-analysis-mechanisms)
+  - [1.8 Privacy](#18-privacy)
+    - [1.8.1 The app minimizes access to sensitive data and resources.](#181-the-app-minimizes-access-to-sensitive-data-and-resources)
+    - [1.8.2 The app is transparent about data collection and usage.](#182-the-app-is-transparent-about-data-collection-and-usage)
+    - [1.8.3 The app offers user control over their data.](#183-the-app-offers-user-control-over-their-data)
+- [2 iOS](#2-ios)
+  - [2.1 Storage](#21-storage)
+    - [2.1.1 The app shall securely store sensitive data](#211-the-app-shall-securely-store-sensitive-data)
+    - [2.1.2 The app prevents leakage of sensitive data](#212-the-app-prevents-leakage-of-sensitive-data)
+  - [2.2 Crypto](#22-crypto)
+    - [2.2.1 The app employs current strong cryptography and uses it according to industry best practices.](#221-the-app-employs-current-strong-cryptography-and-uses-it-according-to-industry-best-practices)
+    - [2.2.2 The app performs key management according to industry best practices.](#222-the-app-performs-key-management-according-to-industry-best-practices)
+  - [2.3 Auth](#23-auth)
+    - [2.3.1 The app uses secure authentication and authorization protocols and follows the relevant best practices.](#231-the-app-uses-secure-authentication-and-authorization-protocols-and-follows-the-relevant-best-practices)
+  - [2.4 Network](#24-network)
+    - [2.4.1 The app secures all network traffic according to the current best practices.](#241-the-app-secures-all-network-traffic-according-to-the-current-best-practices)
+  - [2.5 Platform](#25-platform)
+    - [2.5.1 The app uses IPC mechanisms securely.](#251-the-app-uses-ipc-mechanisms-securely)
+    - [2.5.2 The app uses WebViews securely.](#252-the-app-uses-webviews-securely)
+    - [2.5.3 The app uses the user interface securely.](#253-the-app-uses-the-user-interface-securely)
+  - [2.6 Code](#26-code)
+    - [2.6.1 The app requires an up-to-date platform version.](#261-the-app-requires-an-up-to-date-platform-version)
+    - [2.6.2 The app only uses software components without known vulnerabilities.](#262-the-app-only-uses-software-components-without-known-vulnerabilities)
+    - [2.6.3 The app validates and sanitizes all untrusted inputs.](#263-the-app-validates-and-sanitizes-all-untrusted-inputs)
+  - [2.7 Resilience](#27-resilience)
+    - [2.7.1 The app implements anti-tampering mechanisms.](#271-the-app-implements-anti-tampering-mechanisms)
+    - [2.7.2 The app implements anti-static analysis mechanisms](#272-the-app-implements-anti-static-analysis-mechanisms)
+    - [2.7.3 The app implements anti-dynamic analysis mechanisms](#273-the-app-implements-anti-dynamic-analysis-mechanisms)
+  - [2.8 Privacy](#28-privacy)
+    - [2.8.1 The app minimizes access to sensitive data and resources.](#281-the-app-minimizes-access-to-sensitive-data-and-resources)
+    - [2.8.2 The app is transparent about data collection and usage.](#282-the-app-is-transparent-about-data-collection-and-usage)
+    - [2.8.3 The app offers user control over their data.](#283-the-app-offers-user-control-over-their-data)
 
 # 1 ANDROID
 
-## 
-    1.1 Storage
+## 1.1 Storage
 
+### 1.1.1 The app shall securely store sensitive data
 
-### **1.1.1 The app shall securely store sensitive data**
+#### Description
+This control ensures that any sensitive data that is intentionally stored by the app is properly protected independently of the target location.
 
-**Description**
+#### Rationale
+Apps handle sensitive data coming from many sources such as the user, the backend, system services or other apps on the device and usually need to store it locally. The storage locations may be private to the app (e.g. its internal storage) or be public and therefore accessible by the user or other installed apps (e.g. public folders such as Downloads).
 
-This control ensures that any sensitive data that is intentionally stored by the app is properly protected independently of the target location.  
-
-**Rationale**
-
-Apps handle sensitive data coming from many sources such as the user, the backend, system services or other apps on the device and usually need to store it locally. The storage locations may be private to the app (e.g. its internal storage) or be public and therefore accessible by the user or other installed apps (e.g. public folders such as Downloads). 
-
-**Audit**
-
-
+#### Audit
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.1.1.1
-   </td>
-   <td>The app shall securely store sensitive data
-   </td>
+   <td>1.1.1.1</td>
+   <td>The app shall securely store sensitive data</td>
   </tr>
 </table>
 
 
+### 1.1.2 The app prevents leakage of sensitive data
 
-
-
-### **1.1.2 The app prevents leakage of sensitive data**
-
-**Description**
-
+#### Description
 This control covers unintentional data leaks where the developer actually has a way to prevent it.
 
-**Rationale**
+#### Rationale
+There are cases when sensitive data is unintentionally stored or exposed to publicly accessible locations; typically as a side-effect of using certain APIs, system capabilities such as backups or logs.
 
-There are cases when sensitive data is unintentionally stored or exposed to publicly accessible locations; typically as a side-effect of using certain APIs, system capabilities such as backups or logs. 
-
-**Audit**
-
-
+#### Audit
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.1.2.1
-   </td>
-   <td>The Keyboard Cache shall be disabled for sensitive data inputs.
-   </td>
+   <td>1.1.2.1</td>
+   <td>The Keyboard Cache shall be disabled for sensitive data inputs.</td>
   </tr>
   <tr>
-   <td>1.1.2.2
-   </td>
-   <td>No sensitive data shall be stored in system logs
-   </td>
+   <td>1.1.2.2</td>
+   <td>No sensitive data shall be stored in system logs</td>
   </tr>
 </table>
 
 
 
-## 
-    1.2 Crypto
+## 1.2 Crypto
 
+### 1.2.1 The app employs current strong cryptography and uses it according to industry best practices.
 
-### **1.2.1 The app employs current strong cryptography and uses it according to industry best practices.**
-
-**Description**
-
+#### Description
 This control covers general cryptography best practices, which are typically defined in external standards.  For testing, the Crypto requirements only apply to sensitive data stored outside of the application sandbox.
 
-**Rationale**
-
+#### Rationale
 Cryptography plays an especially important role in securing the user's data - even more so in a mobile environment, where attackers having physical access to the user's device is a likely scenario.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.2.1.1
-   </td>
-   <td>No insecure random number generators shall be utilized for any security sensitive context.
-   </td>
+   <td>1.2.1.1</td>
+   <td>No insecure random number generators shall be utilized for any security sensitive context.</td>
   </tr>
   <tr>
-   <td>1.2.1.2
-   </td>
-   <td>No insecure operations shall be used for symmetric cryptography.
-   </td>
+   <td>1.2.1.2</td>
+   <td>No insecure operations shall be used for symmetric cryptography.</td>
   </tr>
   <tr>
-   <td>1.2.1.3
-   </td>
-   <td>Strong cryptography shall be implemented according to industry best practices.
-   </td>
+   <td>1.2.1.3</td>
+   <td>Strong cryptography shall be implemented according to industry best practices.</td>
   </tr>
 </table>
 
 
 
-### **1.2.2 The app performs key management according to industry best practices.**
+### 1.2.2 The app performs key management according to industry best practices.
 
-**Description**
-
+#### Description
 This control covers the management of cryptographic keys throughout their lifecycle, including key generation, storage and protection. Crypto requirements only apply to sensitive data stored outside of the application sandbox.
 
-**Rationale**
-
+#### Rationale
 Even the strongest cryptography would be compromised by poor key management.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.2.2.1
-   </td>
-   <td>Cryptographic keys shall only be used for their defined purpose.
-   </td>
+   <td>1.2.2.1</td>
+   <td>Cryptographic keys shall only be used for their defined purpose.</td>
   </tr>
   <tr>
-   <td>1.2.2.2
-   </td>
-   <td>Cryptographic key management shall be implemented properly.
-   </td>
+   <td>1.2.2.2</td>
+   <td>Cryptographic key management shall be implemented properly.</td>
   </tr>
 </table>
 
 
 
-## 
-    1.3 Auth
+## 1.3 Auth
 
 
-### **1.3.1 The app uses secure authentication and authorization protocols and follows the relevant best practices.**
+### 1.3.1 The app uses secure authentication and authorization protocols and follows the relevant best practices.
 
-**Description**
-
+#### Description
 Most apps connecting to a remote endpoint require user authentication and also enforce some kind of authorization. While the enforcement of these mechanisms must be on the remote endpoint, the apps also have to ensure that it follows all the relevant best practices to ensure a secure use of the involved protocols.
 
-**Rationale**
-
+#### Rationale
 Authentication and authorization provide an added layer of security and help prevent unauthorized access to sensitive user data.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.3.1.1
-   </td>
-   <td>If using OAuth 2.0 to authenticate, Proof Key for Code Exchange (PKCE) shall be implemented to protect the code grant
-   </td>
+   <td>1.3.1.1</td>
+   <td>If using OAuth 2.0 to authenticate, Proof Key for Code Exchange (PKCE) shall be implemented to protect the code grant</td>
   </tr>
 </table>
 
 
 
-## 
-    1.4 Network
+## 1.4 Network
 
 
-### **1.4.1 The app secures all network traffic according to the current best practices.**
+### 1.4.1 The app secures all network traffic according to the current best practices.
 
-**Description**
-
+#### Description
 This control ensures that the app is in fact setting up secure connections in any situation. This is typically done by encrypting data and authenticating the remote endpoint, as TLS does. However, there are many ways for a developer to disable the platform secure defaults, or bypass them completely by using low-level APIs or third-party libraries.
 
-**Rationale**
+#### Rationale
+Ensuring data privacy and integrity of any data in transit is critical for any app that communicates over the network.
 
-Ensuring data privacy and integrity of any data in transit is critical for any app that communicates over the network. 
-
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.4.1.1
-   </td>
-   <td>Network connections shall be encrypted
-   </td>
+   <td>1.4.1.1</td>
+   <td>Network connections shall be encrypted</td>
   </tr>
   <tr>
-   <td>1.4.1.2
-   </td>
-   <td>TLS configuration of network connections shall adhere to industry best practices
-   </td>
+   <td>1.4.1.2</td>
+   <td>TLS configuration of network connections shall adhere to industry best practices</td>
   </tr>
   <tr>
-   <td>1.4.1.3
-   </td>
-   <td>Endpoint identity shall be verified on network connections
-   </td>
+   <td>1.4.1.3</td>
+   <td>Endpoint identity shall be verified on network connections</td>
   </tr>
 </table>
 
 
 
-## 
-    1.5 Platform
+## 1.5 Platform
 
 
-### **1.5.1 The app uses IPC mechanisms securely.**
+### 1.5.1 The app uses IPC mechanisms securely.
 
-**Description**
-
+#### Description
 This control ensures that all interactions involving IPC mechanisms happen securely.
 
-**Rationale**
-
+#### Rationale
 Apps typically use platform provided IPC mechanisms to intentionally expose data or functionality. Both installed apps and the user are able to interact with the app in many different ways.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td ><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.5.1.1
-   </td>
-   <td>The app shall limit content provider exposure and harden queries against injection attacks
-   </td>
+   <td>1.5.1.1</td>
+   <td>The app shall limit content provider exposure and harden queries against injection attacks</td>
   </tr>
   <tr>
-   <td>1.5.1.2
-   </td>
-   <td>The app shall use verified links and sanitize all link input data
-   </td>
+   <td>1.5.1.2</td>
+   <td>The app shall use verified links and sanitize all link input data</td>
   </tr>
   <tr>
-   <td>1.5.1.3
-   </td>
-   <td>Any sensitive functionality exposed via IPC shall be intentional and at the minimum required level.
-   </td>
+   <td>1.5.1.3</td>
+   <td>Any sensitive functionality exposed via IPC shall be intentional and at the minimum required level.</td>
   </tr>
   <tr>
-   <td>1.5.1.4
-   </td>
-   <td>All Pending Intents shall be immutable or otherwise justified for mutability
-   </td>
+   <td>1.5.1.4</td>
+   <td>All Pending Intents shall be immutable or otherwise justified for mutability</td>
   </tr>
 </table>
 
 
+### 1.5.2 The app uses WebViews securely.
 
-### **1.5.2 The app uses WebViews securely.**
-
-**Description**
-
+#### Description
 This control ensures that WebViews are configured securely to prevent sensitive data leakage as well as sensitive functionality exposure (e.g. via JavaScript bridges to native code).
 
-**Rationale**
-
+#### Rationale
 WebViews are typically used by apps that have a need for increased control over the UI. They can, however, also be exploited by attackers or other installed apps, potentially compromising the app's security.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.5.2.1
-   </td>
-   <td>WebViews shall securely execute JavaScript
-   </td>
+   <td>1.5.2.1</td>
+   <td>WebViews shall securely execute JavaScript</td>
   </tr>
   <tr>
-   <td>1.5.2.2
-   </td>
-   <td>WebView shall be configured to allow the minimum set of protocol handlers required while disabling potentially dangerous handlers.
-   </td>
+   <td>1.5.2.2</td>
+   <td>WebView shall be configured to allow the minimum set of protocol handlers required while disabling potentially dangerous handlers.</td>
   </tr>
 </table>
 
 
 
-### **1.5.3 The app uses the user interface securely.**
+### 1.5.3 The app uses the user interface securely.
 
-**Description**
-
+#### Description
 This control ensures that this data doesn't end up being unintentionally leaked due to platform mechanisms such as auto-generated screenshots or accidentally disclosed via e.g. shoulder surfing or sharing the device with another person.
 
-**Rationale**
-
+#### Rationale
 Sensitive data has to be displayed in the UI in many situations (e.g. passwords, credit card details, OTP codes in notifications) which can lead to unintentional leaks.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.5.3.1
-   </td>
-   <td>The app shall by default mask data in the User Interface when it is known to be sensitive
-   </td>
+   <td>1.5.3.1</td>
+   <td>The app shall by default mask data in the User Interface when it is known to be sensitive</td>
   </tr>
 </table>
 
 
 
-## 
-    1.6 Code
+## 1.6 Code
 
 
-### **[1.6.1 The app requires an up-to-date platform version.](https://mas.owasp.org/MASVS/controls/MASVS-CODE-1/)**
+### 1.6.1 The app requires an up-to-date platform version.
 
-**Description**
-
+#### Description
 This control ensures that the app is running on an up-to-date platform version so that users have the latest security protections.
 
-**Rationale**
-
+#### Rationale
 Every release of the mobile OS includes security patches and new security features. By supporting older versions, apps stay vulnerable to well-known threats.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.6.1.1
-   </td>
-   <td>The app shall set the targetSdkVersion to an up-to-date platform version
-   </td>
+   <td>1.6.1.1</td>
+   <td>The app shall set the targetSdkVersion to an up-to-date platform version</td>
   </tr>
 </table>
 
 
 
-### **1.6.2 The app only uses software components without known vulnerabilities.**
+### 1.6.2 The app only uses software components without known vulnerabilities.
 
-**Description**
-
+#### Description
 To be truly secure, a full whitebox assessment should have been performed on all app components. However, as it usually happens with e.g. for third-party components this is not always feasible and not typically part of a penetration test. This control covers "low-hanging fruit" cases, such as those that can be detected just by scanning libraries for known vulnerabilities.
 
-**Rationale**
-
+#### Rationale
 The developer should protect users from known vulnerabilities.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.6.2.1
-   </td>
-   <td>The app only uses software components without known vulnerabilities
-   </td>
+   <td>1.6.2.1</td>
+   <td>The app only uses software components without known vulnerabilities</td>
   </tr>
 </table>
 
 
 
-### **1.6.3 The app validates and sanitizes all untrusted inputs.**
+### 1.6.3 The app validates and sanitizes all untrusted inputs.
 
-**Description**
-
+#### Description
 Apps have many data entry points including the UI, IPC, the network, the file system, etc.  This control ensures that this data is treated as untrusted input and is properly verified and sanitized before it's used.
 
-**Rationale**
-
+#### Rationale
 This incoming data might have been inadvertently modified by untrusted actors and may lead to bypass of critical security checks as well as classical injection attacks such as SQL injection, XSS or insecure deserialization.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.6.3.1
-   </td>
-   <td>Compiler security features shall be enabled
-   </td>
+   <td>1.6.3.1</td>
+   <td>Compiler security features shall be enabled</td>
   </tr>
   <tr>
-   <td>1.6.3.2
-   </td>
-   <td>The App shall Mitigate Against Injection Flaws in Content Providers
-   </td>
+   <td>1.6.3.2</td>
+   <td>The App shall Mitigate Against Injection Flaws in Content Providers</td>
   </tr>
   <tr>
-   <td>1.6.3.3
-   </td>
-   <td>Arbitrary URL redirects shall not be included in the app's webviews
-   </td>
+   <td>1.6.3.3</td>
+   <td>Arbitrary URL redirects shall not be included in the app's webviews</td>
   </tr>
   <tr>
-   <td>1.6.3.4
-   </td>
-   <td>Any use of implicit intents shall be appropriate for the app's functionality and any return data shall be handled securely
-   </td>
+   <td>1.6.3.4</td>
+   <td>Any use of implicit intents shall be appropriate for the app's functionality and any return data shall be handled securely</td>
   </tr>
 </table>
 
 
 
-## 
-    1.7 Resilience
+## 1.7 Resilience
 
 
-### **1.7.1 The app implements anti-tampering mechanisms.**
+### 1.7.1 The app implements anti-tampering mechanisms.
 
-**Description**
-
+#### Description
 This control tries to ensure the integrity of the app's intended functionality by preventing modifications to the original code and resources.
 
-**Rationale**
-
+#### Rationale
 Apps run on a user-controlled device, and without proper protections it's relatively easy to run a modified version locally (e.g. to cheat in a game, or enable premium features without paying), or upload a backdoored version of it to third-party app stores.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.7.1.1
-   </td>
-   <td>The app shall be properly signed.
-   </td>
+   <td>1.7.1.1</td>
+   <td>The app shall be properly signed.</td>
   </tr>
 </table>
 
 
 
-### **1.7.2 The app implements anti-static analysis mechanisms**
+### 1.7.2 The app implements anti-static analysis mechanisms
 
-**Description**
-
+#### Description
 This control tries to impede comprehension by making it as difficult as possible to figure out how an app works using static analysis.
 
-**Rationale**
-
+#### Rationale
 Understanding the internals of an app is typically the first step towards tampering with it.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.7.2.1
-   </td>
-   <td>The app shall disable all debugging symbols in the production version.
-   </td>
+   <td>1.7.2.1</td>
+   <td>The app shall disable all debugging symbols in the production version.</td>
   </tr>
 </table>
 
 
 
-### **[1.7.3 The app implements anti-dynamic analysis mechanisms](https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-4/)**
+### [1.7.3 The app implements anti-dynamic analysis mechanisms](https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-4/)
 
-**Description**
-
+#### Description
 Sometimes pure static analysis is very difficult and time consuming so it typically goes hand in hand with dynamic analysis.  This control aims to make it as difficult as possible to perform dynamic analysis, as well as prevent dynamic instrumentation which could allow an attacker to modify the code at runtime.
 
-**Rationale**
+#### Rationale
+Observing and manipulating an app during runtime makes it much easier to decipher its behavior.
 
-Observing and manipulating an app during runtime makes it much easier to decipher its behavior. 
-
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.7.3.1
-   </td>
-   <td>The app shall not be debuggable if installed from outside of commercial app stores.
-   </td>
+   <td>1.7.3.1</td>
+   <td>The app shall not be debuggable if installed from outside of commercial app stores.</td>
   </tr>
 </table>
 
 
 
-## 
-    1.8 Privacy
+## 1.8 Privacy
 
 
-### **1.8.1 The app minimizes access to sensitive data and resources.**
+### 1.8.1 The app minimizes access to sensitive data and resources.
 
-**Description**
+#### Description
+Apps should only request access to the data they absolutely need for their functionality and always with informed consent from the user. This control ensures that apps practice data minimization and restricts access control.  Furthermore, apps should share data with third parties only when necessary, and this should include enforcing that third-party SDKs operate based on user consent, not by default or without it. Apps should prevent third-party SDKs from ignoring consent signals or from collecting data before consent is confirmed.  Additionally, apps should be aware of the 'supply chain' of SDKs they incorporate, ensuring that no data is unnecessarily passed down their chain of dependencies.
 
-Apps should only request access to the data they absolutely need for their functionality and always with informed consent from the user. This control ensures that apps practice data minimization and restricts access control.  Furthermore, apps should share data with third parties only when necessary, and this should include enforcing that third-party SDKs operate based on user consent, not by default or without it. Apps should prevent third-party SDKs from ignoring consent signals or from collecting data before consent is confirmed.  Additionally, apps should be aware of the 'supply chain' of SDKs they incorporate, ensuring that no data is unnecessarily passed down their chain of dependencies. 
-
-**Rationale**
-
+#### Rationale
 Data minimization reduces the potential impact of data breaches or leaks.  This end-to-end responsibility for data aligns with recent SBOM regulatory requirements, making apps more accountable for their data practices.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.8.1.1
-   </td>
-   <td>The app shall minimize access to sensitive data and resources provided by the platform.
-   </td>
+   <td>1.8.1.1</td>
+   <td>The app shall minimize access to sensitive data and resources provided by the platform.</td>
   </tr>
 </table>
 
 
 
-### **1.8.2 The app is transparent about data collection and usage.**
+### 1.8.2 The app is transparent about data collection and usage.
 
-**Description**
-
+#### Description
 This control ensures that apps provide clear information about data collection, storage, and sharing practices, including any behavior a user wouldn't reasonably expect, such as background data collection. Apps should also adhere to platform guidelines on data declarations.
 
-**Rationale**
+#### Rationale
+Users have the right to know how their data is being used.
 
-Users have the right to know how their data is being used. 
-
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.8.2.1
-   </td>
-   <td>The app shall be transparent about data collection and usage.
-   </td>
+   <td>1.8.2.1</td>
+   <td>The app shall be transparent about data collection and usage.</td>
   </tr>
 </table>
 
 
 
-### **1.8.3 The app offers user control over their data.**
+### 1.8.3 The app offers user control over their data.
 
-**Description**
-
+#### Description
 This control ensures that apps provide mechanisms for users to manage, delete, and modify their data, and change privacy settings as needed (e.g. to revoke consent). Additionally, apps should re-prompt for consent and update their transparency disclosures when they require more data than initially specified.
 
-**Rationale**
-
+#### Rationale
 Users should have control over their data.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>1.8.3.1
-   </td>
-   <td>Users shall have the ability to request their data to be deleted via an in-app mechanism.
-   </td>
+   <td>1.8.3.1</td>
+   <td>Users shall have the ability to request their data to be deleted via an in-app mechanism.</td>
   </tr>
 </table>
 
@@ -875,27 +639,21 @@ Users should have control over their data.
 # 2 iOS
 
 
-## 
-    2.1 Storage
+## 2.1 Storage
 
 
-### **2.1.1 The app shall securely store sensitive data**
+### 2.1.1 The app shall securely store sensitive data
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.1.1.1
-   </td>
-   <td>The app shall securely store sensitive data
-   </td>
+   <td>2.1.1.1</td>
+   <td>The app shall securely store sensitive data</td>
   </tr>
 </table>
 
@@ -903,468 +661,354 @@ Users should have control over their data.
 
 
 
-### **2.1.2 The app prevents leakage of sensitive data**
+### 2.1.2 The app prevents leakage of sensitive data
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.1.2.1
-   </td>
-   <td>The Keyboard Cache shall be Disabled for sensitive data inputs.
-   </td>
+   <td>2.1.2.1</td>
+   <td>The Keyboard Cache shall be Disabled for sensitive data inputs.</td>
   </tr>
   <tr>
-   <td>2.1.2.2
-   </td>
-   <td>No sensitive data shall be stored in system logs
-   </td>
+   <td>2.1.2.2</td>
+   <td>No sensitive data shall be stored in system logs</td>
   </tr>
 </table>
 
 
 
-## 
-    2.2 Crypto
+## 2.2 Crypto
 
 
-### **2.2.1 The app employs current strong cryptography and uses it according to industry best practices.**
+### 2.2.1 The app employs current strong cryptography and uses it according to industry best practices.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.2.1.1
-   </td>
-   <td>No insecure random number generators shall be utilized for any security sensitive context.
-   </td>
+   <td>2.2.1.1</td>
+   <td>No insecure random number generators shall be utilized for any security sensitive context.</td>
   </tr>
   <tr>
-   <td>2.2.1.2
-   </td>
-   <td>Strong cryptography shall be implemented according to industry best practices.
-   </td>
+   <td>2.2.1.2</td>
+   <td>Strong cryptography shall be implemented according to industry best practices.</td>
   </tr>
 </table>
 
 
 
-### **2.2.2 The app performs key management according to industry best practices.**
+### 2.2.2 The app performs key management according to industry best practices.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.2.2.1
-   </td>
-   <td>Cryptographic keys shall only be used for their defined purpose.
-   </td>
+   <td>2.2.2.1</td>
+   <td>Cryptographic keys shall only be used for their defined purpose.</td>
   </tr>
   <tr>
-   <td>2.2.2.2
-   </td>
-   <td>Cryptographic key management shall be implemented properly.
-   </td>
+   <td>2.2.2.2</td>
+   <td>Cryptographic key management shall be implemented properly.</td>
   </tr>
 </table>
 
 
 
-## 
-    2.3 Auth
+## 2.3 Auth
 
 
-### **2.3.1 The app uses secure authentication and authorization protocols and follows the relevant best practices.**
+### 2.3.1 The app uses secure authentication and authorization protocols and follows the relevant best practices.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.3.1.1
-   </td>
-   <td>If using OAuth 2.0 to authenticate, Proof Key for Code Exchange (PKCE) shall be implemented to protect the code grant
-   </td>
+   <td>2.3.1.1</td>
+   <td>If using OAuth 2.0 to authenticate, Proof Key for Code Exchange (PKCE) shall be implemented to protect the code grant</td>
   </tr>
 </table>
 
 
 
-## 
-    2.4 Network
+## 2.4 Network
 
 
-### **2.4.1 The app secures all network traffic according to the current best practices.**
+### 2.4.1 The app secures all network traffic according to the current best practices.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.4.1.1
-   </td>
-   <td>Network connections shall be encrypted
-   </td>
+   <td>2.4.1.1</td>
+   <td>Network connections shall be encrypted</td>
   </tr>
   <tr>
-   <td>2.4.1.2
-   </td>
-   <td>TLS configuration of network connections shall adhere to industry best practices
-   </td>
+   <td>2.4.1.2</td>
+   <td>TLS configuration of network connections shall adhere to industry best practices</td>
   </tr>
   <tr>
-   <td>2.4.1.3
-   </td>
-   <td>Endpoint identity shall be verified on network connections
-   </td>
+   <td>2.4.1.3</td>
+   <td>Endpoint identity shall be verified on network connections</td>
   </tr>
 </table>
 
 
 
-## 
-    2.5 Platform
+## 2.5 Platform
 
 
-### **2.5.1 The app uses IPC mechanisms securely.**
+### 2.5.1 The app uses IPC mechanisms securely.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.5.1.1
-   </td>
-   <td>The app shall not expose sensitive data via IPC mechanisms
-   </td>
+   <td>2.5.1.1</td>
+   <td>The app shall not expose sensitive data via IPC mechanisms</td>
   </tr>
   <tr>
-   <td>2.5.1.2
-   </td>
-   <td>The app shall not expose sensitive data via App Extensions
-   </td>
+   <td>2.5.1.2</td>
+   <td>The app shall not expose sensitive data via App Extensions</td>
   </tr>
   <tr>
-   <td>2.5.1.3
-   </td>
-   <td>The app shall not expose sensitive functionality via Custom URL Schemes
-   </td>
+   <td>2.5.1.3</td>
+   <td>The app shall not expose sensitive functionality via Custom URL Schemes</td>
   </tr>
   <tr>
-   <td>2.5.1.4
-   </td>
-   <td>The app shall not expose sensitive data via UIActivity Sharing
-   </td>
+   <td>2.5.1.4</td>
+   <td>The app shall not expose sensitive data via UIActivity Sharing</td>
   </tr>
   <tr>
-   <td>2.5.1.5
-   </td>
-   <td>The app shall not use the general pasteboard for sharing sensitive information
-   </td>
+   <td>2.5.1.5</td>
+   <td>The app shall not use the general pasteboard for sharing sensitive information</td>
   </tr>
   <tr>
-   <td>2.5.1.6
-   </td>
-   <td>The app shall not expose sensitive functionality via Universal Links
-   </td>
+   <td>2.5.1.6</td>
+   <td>The app shall not expose sensitive functionality via Universal Links</td>
   </tr>
 </table>
 
 
 
-### **2.5.2 The app uses WebViews securely.**
+### 2.5.2 The app uses WebViews securely.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.5.2.1
-   </td>
-   <td>WebViews shall securely execute JavaScript
-   </td>
+   <td>2.5.2.1</td>
+   <td>WebViews shall securely execute JavaScript</td>
   </tr>
   <tr>
-   <td>2.5.2.2
-   </td>
-   <td>WebView shall be configured securely
-   </td>
+   <td>2.5.2.2</td>
+   <td>WebView shall be configured securely</td>
   </tr>
 </table>
 
 
 
-### **2.5.3 The app uses the user interface securely.**
+### 2.5.3 The app uses the user interface securely.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.5.3.1
-   </td>
-   <td>The app shall by default mask data in the User Interface when it is known to be sensitive
-   </td>
+   <td>2.5.3.1</td>
+   <td>The app shall by default mask data in the User Interface when it is known to be sensitive</td>
   </tr>
 </table>
 
 
 
-## 
-    2.6 Code
+## 2.6 Code
 
 
-### **2.6.1 The app requires an up-to-date platform version.**
+### 2.6.1 The app requires an up-to-date platform version.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.6.1.1
-   </td>
-   <td>The app shall set the targetSdkVersion to an up-to-date platform version
-   </td>
+   <td>2.6.1.1</td>
+   <td>The app shall set the targetSdkVersion to an up-to-date platform version</td>
   </tr>
 </table>
 
 
 
-### **2.6.2 The app only uses software components without known vulnerabilities.**
+### 2.6.2 The app only uses software components without known vulnerabilities.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.6.2.1
-   </td>
-   <td>The app only uses software components without known vulnerabilities
-   </td>
+   <td>2.6.2.1</td>
+   <td>The app only uses software components without known vulnerabilities</td>
   </tr>
 </table>
 
 
 
-### **2.6.3 The app validates and sanitizes all untrusted inputs.**
+### 2.6.3 The app validates and sanitizes all untrusted inputs.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.6.3.1
-   </td>
-   <td>Compiler security features shall be enabled
-   </td>
+   <td>2.6.3.1</td>
+   <td>Compiler security features shall be enabled</td>
   </tr>
 </table>
 
 
 
-## 
-    2.7 Resilience
+## 2.7 Resilience
 
 
-### **2.7.1 The app implements anti-tampering mechanisms.**
+### 2.7.1 The app implements anti-tampering mechanisms.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.7.1.1
-   </td>
-   <td>The app shall be properly signed.
-   </td>
+   <td>2.7.1.1</td>
+   <td>The app shall be properly signed.</td>
   </tr>
 </table>
 
 
 
-### **2.7.2 The app implements anti-static analysis mechanisms**
+### 2.7.2 The app implements anti-static analysis mechanisms
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.7.2.1
-   </td>
-   <td>The app shall disable all debugging symbols in the production version.
-   </td>
+   <td>2.7.2.1</td>
+   <td>The app shall disable all debugging symbols in the production version.</td>
   </tr>
 </table>
 
 
 
-### **2.7.3 The app implements anti-dynamic analysis mechanisms**
+### 2.7.3 The app implements anti-dynamic analysis mechanisms
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.7.3.1
-   </td>
-   <td>The app shall not be debuggable if installed from outside of commercial app stores.
-   </td>
+   <td>2.7.3.1</td>
+   <td>The app shall not be debuggable if installed from outside of commercial app stores.</td>
   </tr>
 </table>
 
 
 
-## 
-    2.8 Privacy
+## 2.8 Privacy
 
 
-### **2.8.1 The app minimizes access to sensitive data and resources.**
+### 2.8.1 The app minimizes access to sensitive data and resources.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.8.1.1
-   </td>
-   <td>The app shall minimize access to sensitive data and resources provided by the platform.
-   </td>
+   <td>2.8.1.1</td>
+   <td>The app shall minimize access to sensitive data and resources provided by the platform.</td>
   </tr>
 </table>
 
 
 
-### **2.8.2 The app is transparent about data collection and usage.**
+### 2.8.2 The app is transparent about data collection and usage.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.8.2.1
-   </td>
-   <td>The app shall be transparent about data collection and usage.
-   </td>
+   <td>2.8.2.1</td>
+   <td>The app shall be transparent about data collection and usage.</td>
   </tr>
 </table>
 
 
 
-### **2.8.3 The app offers user control over their data.**
+### 2.8.3 The app offers user control over their data.
 
-**Audit**
-
+#### Audit
 
 <table>
   <tr>
-   <td style="background-color: null"><strong>Spec</strong>
-   </td>
-   <td style="background-color: null"><strong>Description</strong>
-   </td>
+   <td><strong>Spec</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>2.8.3.1
-   </td>
-   <td>Users shall have the ability to request their data to be deleted via an in-app mechanism.
-   </td>
+   <td>2.8.3.1</td>
+   <td>Users shall have the ability to request their data to be deleted via an in-app mechanism.</td>
   </tr>
 </table>

--- a/Mobile App Profile/Mobile App Test Guide.md
+++ b/Mobile App Profile/Mobile App Test Guide.md
@@ -1,197 +1,153 @@
-# **App Defense Alliance Mobile Application Test Guide**
+# App Defense Alliance Mobile Application Specification
 
 Version 0.7 - June 14, 2024
 
-
-# **Revision History**
-
+## Revision History
 
 <table>
   <tr>
-   <td><strong>Version</strong>
-   </td>
-   <td><strong>Date</strong>
-   </td>
-   <td><strong>Description</strong>
-   </td>
+   <td><strong>Version</strong></td>
+   <td><strong>Date</strong></td>
+   <td><strong>Description</strong></td>
   </tr>
   <tr>
-   <td>0.5
-   </td>
-   <td>5/10/24
-   </td>
-   <td>Initial draft based on Mobile App Tiger Team review of MASVS specification
-   </td>
+   <td>0.5</td>
+   <td>5/10/24</td>
+   <td>Initial draft based on Mobile App Tiger Team review of MASVS specification</td>
   </tr>
   <tr>
-   <td style="background-color: #f3f3f3">0/7
-   </td>
-   <td style="background-color: #f3f3f3">5/25/24
-   </td>
-   <td style="background-color: #f3f3f3">Updates from TIger Team review of 0.5 spec
-   </td>
+   <td>0.7</td>
+   <td>5/25/24</td>
+   <td>Updates from Tiger Team review of 0.5 spec</td>
   </tr>
 </table>
 
+## Contributors
+The App Defense Alliance Application Security Assessment Working Group (ASA WG) would like to thank the following individuals for their contributions to this specification:
 
+* Alex Duff (ASA WG Chair)
+* Brooke Davis (ASA WG Vice Chair)
+* Anna Bhirud
+* Antonio Nappa
+* Brad Ree
+* Cody Martin
+* Corey Gagnon
+* Eugene Liderman
+* Joel Scambray
+* Jorge Damian
+* José María Santos López
+* Juan Manuel Martinez Hernandez
+* Jullian Gerhart
+* Olivier Tuchon
+* Peter Mueller
+* Riccardo Poffo
+* Rupesh Nair
+* Syrone Hanks II
+* Thomas Cannon
+* Tim Bolton
+* Yiannis Kozyrakis
 
-# **Table of Contents**
-
-**Android**
-
-1.1 [Storage](https://mas.owasp.org/MASVS/05-MASVS-STORAGE/)
-
-1.1.1 [The app security stores sensitive data](https://mas.owasp.org/MASVS/controls/MASVS-STORAGE-1/)
-
-1.1.2 [The app prevents leakage of sensitive data](https://mas.owasp.org/MASVS/controls/MASVS-STORAGE-2/)
-
-1.2 [Crypto](https://mas.owasp.org/MASVS/06-MASVS-CRYPTO/)
-
-1.2.1 [The app employs strong cryptography and uses it according to industry best practices](https://mas.owasp.org/MASVS/controls/MASVS-CRYPTO-1/)
-
-1.2.2 [The app performs key management according to industry best practices](https://mas.owasp.org/MASVS/controls/MASVS-CRYPTO-2/)
-
-1.3 [Auth](https://mas.owasp.org/MASVS/07-MASVS-AUTH/)
-
-1.3.1 [The app uses secure authentication and authorization protocols and follows the relevant best practices](https://mas.owasp.org/MASVS/controls/MASVS-AUTH-1/)
-
-1.4 [Network](https://mas.owasp.org/MASVS/08-MASVS-NETWORK/)
-
-1.4.1 [The app secures all network traffic according to the current best practices](https://mas.owasp.org/MASVS/controls/MASVS-NETWORK-1/)
-
-1.5 [Platform](https://mas.owasp.org/MASVS/09-MASVS-PLATFORM/)
-
-1.5.1 [The app uses IPC mechanisms securely](https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-1/)
-
-1.5.2 [The app uses WebViews securely](https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-2/)
-
-1.5.3 [The app uses the user interface securely](https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-3/)
-
-1.6 [Code](https://mas.owasp.org/MASVS/10-MASVS-CODE/)
-
-1.6.1 [The app requires an up-to-date platform version](https://mas.owasp.org/MASVS/controls/MASVS-CODE-1/)
-
-1.6.2 [The app only uses software components without known vulnerabilities](https://mas.owasp.org/MASVS/controls/MASVS-CODE-3/)
-
-1.6.3 [The app validates and sanitizes all untrusted inputs](https://mas.owasp.org/MASVS/controls/MASVS-CODE-4/)
-
-1.7 [Resilience](https://mas.owasp.org/MASVS/11-MASVS-RESILIENCE/)
-
-1.7.1 [The app implements anti-tampering mechanisms](https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-2/)
-
-1.7.2 [The app implements anti-static analysis mechanisms](https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-3/)
-
-1.7.3 [The app implements anti-dynamic analysis techniques](https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-4/)
-
-1.8 [Privacy](https://mas.owasp.org/MASVS/12-MASVS-PRIVACY/)
-
-1.8.1 [The app minimizes access to sensitive data and resources](https://mas.owasp.org/MASVS/controls/MASVS-PRIVACY-1/)
-
-1.8.2 [The app is transparent about data collection and usage](https://mas.owasp.org/MASVS/controls/MASVS-PRIVACY-3/)
-
-1.8.3 [The app offers user control over their data](https://mas.owasp.org/MASVS/controls/MASVS-PRIVACY-4/)
-
-**iOS**
-
-2.1 [Storage](https://mas.owasp.org/MASVS/05-MASVS-STORAGE/)
-
-2.1.1 [The app security stores sensitive data](https://mas.owasp.org/MASVS/controls/MASVS-STORAGE-1/)
-
-2.1.2 [The app prevents leakage of sensitive data](https://mas.owasp.org/MASVS/controls/MASVS-STORAGE-2/)
-
-2.2 [Crypto](https://mas.owasp.org/MASVS/06-MASVS-CRYPTO/)
-
-2.2.1 [The app employs strong cryptography and uses it according to industry best practices](https://mas.owasp.org/MASVS/controls/MASVS-CRYPTO-1/)
-
-2.2.2 [The app performs key management according to industry best practices](https://mas.owasp.org/MASVS/controls/MASVS-CRYPTO-2/)
-
-2.3 [Auth](https://mas.owasp.org/MASVS/07-MASVS-AUTH/)
-
-2.3.1 [The app uses secure authentication and authorization protocols and follows the relevant best practices](https://mas.owasp.org/MASVS/controls/MASVS-AUTH-1/)
-
-2.4 [Network](https://mas.owasp.org/MASVS/08-MASVS-NETWORK/)
-
-2.4.1 [The app secures all network traffic according to the current best practices](https://mas.owasp.org/MASVS/controls/MASVS-NETWORK-1/)
-
-2.5 [Platform](https://mas.owasp.org/MASVS/09-MASVS-PLATFORM/)
-
-2.5.1 [The app uses IPC mechanisms securely](https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-1/)
-
-2.5.2 [The app uses WebViews securely](https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-2/)
-
-2.5.3 [The app uses the user interface securely](https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-3/)
-
-2.6 [Code](https://mas.owasp.org/MASVS/10-MASVS-CODE/)
-
-2.6.1 [The app requires an up-to-date platform version](https://mas.owasp.org/MASVS/controls/MASVS-CODE-1/)
-
-2.6.2 [The app only uses software components without known vulnerabilities](https://mas.owasp.org/MASVS/controls/MASVS-CODE-3/)
-
-2.6.3 [The app validates and sanitizes all untrusted inputs](https://mas.owasp.org/MASVS/controls/MASVS-CODE-4/)
-
-2.7 [Resilience](https://mas.owasp.org/MASVS/11-MASVS-RESILIENCE/)
-
-2.7.1 [The app implements anti-tampering mechanisms](https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-2/)
-
-2.7.2 [The app implements anti-static analysis mechanisms](https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-3/)
-
-2.7.3 [The app implements anti-dynamic analysis techniques](https://mas.owasp.org/MASVS/controls/MASVS-RESILIENCE-4/)
-
-2.8 [Privacy](https://mas.owasp.org/MASVS/12-MASVS-PRIVACY/)
-
-2.8.1 [The app minimizes access to sensitive data and resources](https://mas.owasp.org/MASVS/controls/MASVS-PRIVACY-1/)
-
-2.8.2 [The app is transparent about data collection and usage](https://mas.owasp.org/MASVS/controls/MASVS-PRIVACY-3/)
-
-2.8.3 [The app offers user control over their data](https://mas.owasp.org/MASVS/controls/MASVS-PRIVACY-4/)
-
-**Introduction**
+## Introduction
 
 In today’s digitally-driven world, mobile applications are the backbone of countless businesses and organizations. Unfortunately, they are also prime targets for cyberattacks that threaten data confidentiality, service availability, and overall business integrity. To mitigate risks and build a secure mobile environment, a robust mobile application security standard and certification program is essential.
 
-**Our Approach: OWASP MASVS as the Foundation**
+### Our Approach: OWASP MASVS as the Foundation
 
 This program leverages the internationally recognized OWASP Mobile Application Security Verification Standard (MASVS) as its core. The OWASP MASVS offers a comprehensive set of security assessment requirements and guidelines covering the entire mobile application development lifecycle. Building upon this base, the App Defense Alliance (ADA) focused on testable requirements with clear acceptance criteria. Further, the ADA approach emphasizes the use of automation where possible.
 
 
-# **Applicability**
+### Applicability
 
 This document is intended for system and application administrators, security specialists, auditors, help desk, platform deployment, and/or DevOps personnel who plan to develop, deploy, assess, or secure mobile applications.
 
 
-# **References**
-
-
+### References
 
 1. [OWASP Mobile Application Security Verification Standard](https://github.com/OWASP/owasp-masvs/)
 
 
-# **Licensing**
+### Licensing
 
 This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License.](https://creativecommons.org/licenses/by-sa/4.0/)
 
 
-# **Assumptions**
+### Assumptions
 
-The following assumptions are intended to aid the Authorized Labs for baseline security testing. 
+The following assumptions are intended to aid the Authorized Labs for baseline security testing.
 
-**PLATFORM**
+#### PLATFORM
 
 The mobile application relies upon a trustworthy computing platform that runs a recent version of a mobile operating system (i.e. N-2) from the date of evaluation.   For the purposes of this document, N refers to a major operation system release.
 
-**PROPER_USER**
+#### PROPER_USER
 
 The user of the application software is not willfully negligent or hostile, and sets a device PIN/Passcode.
 
-**SENSITIVE_DATA**
+#### SENSITIVE_DATA
 
 Data that is of particular concern from a security perspective, including personal identifiable information, credentials, and keys. This is not taking into account regulatory requirements for privacy or compliance for various verticals such as healthcare or finance.
 
 PII is any information that can be used to directly or indirectly identify a specific individual. This data, if mishandled, can lead to harm, discrimination, or privacy violations.
 
-**TOOLING**
+#### TOOLING
 
 The ADA approach emphasizes the use of automation where possible. We expect future tooling investment to assist with gathering of developer evidence for Level 1 assurance.
+
+# Table of Contents
+- [1 ANDROID](#1-android)
+  - [1.1 Storage](#11-storage)
+    - [1.1.1 The app securely stores sensitive data](#111-the-app-securely-stores-sensitive-data)
+    - [1.1.2 The app prevents leakage of sensitive data](#112-the-app-prevents-leakage-of-sensitive-data)
+  - [1.2 Crypto](#12-crypto)
+    - [1.2.1 The app employs current strong cryptography and uses it according to industry best practices](#121-the-app-employs-current-strong-cryptography-and-uses-it-according-to-industry-best-practices)
+    - [1.2.2 The app performs key management according to industry best practices](#122-the-app-performs-key-management-according-to-industry-best-practices)
+  - [1.3 Auth](#13-auth)
+    - [1.3.1 The app uses secure authentication and authorization protocols and follows the relevant best practices](#131-the-app-uses-secure-authentication-and-authorization-protocols-and-follows-the-relevant-best-practices)
+  - [1.4 Network](#14-network)
+    - [1.4.1 The app secures all network traffic according to the current best practices](#141-the-app-secures-all-network-traffic-according-to-the-current-best-practices)
+  - [1.5 Platform](#15-platform)
+    - [1.5.1 The app uses IPC mechanisms securely](#151-the-app-uses-ipc-mechanisms-securely)
+    - [1.5.2 The app uses WebViews securely.](#152-the-app-uses-webviews-securely)
+    - [1.5.3 The app uses the user interface securely.](#153-the-app-uses-the-user-interface-securely)
+  - [1.6 Code](#16-code)
+    - [1.6.1 The app requires an up-to-date platform version](#161-the-app-requires-an-up-to-date-platform-version)
+    - [1.6.2 The app only uses software components without known vulnerabilities](#162-the-app-only-uses-software-components-without-known-vulnerabilities)
+    - [1.6.3 The app validates and sanitizes all untrusted inputs.](#163-the-app-validates-and-sanitizes-all-untrusted-inputs)
+  - [1.7 Resilience](#17-resilience)
+    - [1.7.1 The app implements anti-tampering mechanisms](#171-the-app-implements-anti-tampering-mechanisms)
+    - [1.7.2 The app implements anti-static analysis mechanisms](#172-the-app-implements-anti-static-analysis-mechanisms)
+    - [1.7.3 The app implements anti-dynamic analysis mechanisms](#173-the-app-implements-anti-dynamic-analysis-mechanisms)
+  - [1.8 Privacy](#18-privacy)
+    - [1.8.1 The app minimizes access to sensitive data and resources.](#181-the-app-minimizes-access-to-sensitive-data-and-resources)
+    - [1.8.2 The app is transparent about data collection and usage](#182-the-app-is-transparent-about-data-collection-and-usage)
+    - [1.8.3 The app offers user control over their data](#183-the-app-offers-user-control-over-their-data)
+- [2 iOS](#2-ios)
+  - [2.1 Storage](#21-storage)
+    - [2.1.1 The app securely stores sensitive data](#211-the-app-securely-stores-sensitive-data)
+    - [2.1.2 The app prevents leakage of sensitive data](#212-the-app-prevents-leakage-of-sensitive-data)
+  - [2.2 Crypto](#22-crypto)
+    - [2.2.1 The app employs current strong cryptography and uses it according to industry best practices.](#221-the-app-employs-current-strong-cryptography-and-uses-it-according-to-industry-best-practices)
+    - [2.2.2  The app performs key management according to industry best practices](#222--the-app-performs-key-management-according-to-industry-best-practices)
+  - [2.3 Auth](#23-auth)
+    - [2.3.1 The app uses secure authentication and authorization protocols and follows the relevant best practices.](#231-the-app-uses-secure-authentication-and-authorization-protocols-and-follows-the-relevant-best-practices)
+  - [2.4 Network](#24-network)
+    - [2.4.1 The app secures all network traffic according to the current best practices.](#241-the-app-secures-all-network-traffic-according-to-the-current-best-practices)
+  - [2.5 Platform](#25-platform)
+    - [2.5.1 The app uses IPC mechanisms securely.](#251-the-app-uses-ipc-mechanisms-securely)
+    - [2.5.2 The app uses WebViews securely.](#252-the-app-uses-webviews-securely)
+    - [2.5.3 The app uses the user interface securely.](#253-the-app-uses-the-user-interface-securely)
+  - [2.6 Code](#26-code)
+    - [2.6.1 The app requires an up-to-date platform version.](#261-the-app-requires-an-up-to-date-platform-version)
+    - [2.6.2 The app only uses software components without known vulnerabilities.](#262-the-app-only-uses-software-components-without-known-vulnerabilities)
+    - [2.6.3 The app validates and sanitizes all untrusted inputs.](#263-the-app-validates-and-sanitizes-all-untrusted-inputs)
+  - [2.7 Resilience](#27-resilience)
+    - [2.7.1 The app implements anti-tampering mechanisms.](#271-the-app-implements-anti-tampering-mechanisms)
+    - [2.7.2 The app implements anti-static analysis mechanisms.](#272-the-app-implements-anti-static-analysis-mechanisms)
+    - [2.7.3 The app implements anti-dynamic analysis techniques.](#273-the-app-implements-anti-dynamic-analysis-techniques)
+  - [2.8 Privacy](#28-privacy)
+    - [2.8.1 The app minimizes access to sensitive data and resources.](#281-the-app-minimizes-access-to-sensitive-data-and-resources)
+    - [2.8.2 The app is transparent about data collection and usage.](#282-the-app-is-transparent-about-data-collection-and-usage)
+    - [2.8.3 The app offers user control over their data.](#283-the-app-offers-user-control-over-their-data)
 
 
 # 1 ANDROID
@@ -202,17 +158,17 @@ The ADA approach emphasizes the use of automation where possible. We expect futu
 
 ### 1.1.1 The app securely stores sensitive data
 
-**Description**
+#### Description
 
-This control ensures that any sensitive data that is intentionally stored by the app is properly protected independently of the target location.  
+This control ensures that any sensitive data that is intentionally stored by the app is properly protected independently of the target location.
 
-**Rationale**
+#### Rationale
 
-Apps handle sensitive data coming from many sources such as the user, the backend, system services or other apps on the device and usually need to store it locally. The storage locations may be private to the app (e.g. its internal storage) or be public and therefore accessible by the user or other installed apps (e.g. public folders such as Downloads). 
+Apps handle sensitive data coming from many sources such as the user, the backend, system services or other apps on the device and usually need to store it locally. The storage locations may be private to the app (e.g. its internal storage) or be public and therefore accessible by the user or other installed apps (e.g. public folders such as Downloads).
 
-**Audit**
+#### Audit
 
-**1.1.1.1 The app shall securely store sensitive data.**
+##### 1.1.1.1 The app shall securely store sensitive data.
 
 **Evidence**
 
@@ -222,13 +178,9 @@ L1: Attachment of the Android Manifest. If sensitive data is being written to ex
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0001](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-STORAGE/MASTG-TEST-0001.md).
 
@@ -236,50 +188,42 @@ _L2_
 
 _L1_
 
-
-
-1. The Android Manifest does not declare the use of external storage. 
-2. Or, if sensitive data is being written to external storage, confirm the crypto implementation meets the [baseline crypto requirements](?tab=t.0#heading=h.mkuggelq0e79) by reviewing the relevant screenshot from the design document.
+1. The Android Manifest does not declare the use of external storage.
+2. Or, if sensitive data is being written to external storage, confirm the crypto implementation meets the [baseline crypto requirements](#22-crypto) by reviewing the relevant screenshot from the design document.
 
 _L2_
 
-
-
-1. Output of the analysis shows that the app does not write and store unencrypted and sensitive data in external storage. 
-2. Or, if sensitive data is being written to external storage, verify that the crypto implementation meets the [baseline crypto requirements](?tab=t.0#heading=h.mkuggelq0e79).
+1. Output of the analysis shows that the app does not write and store unencrypted and sensitive data in external storage.
+2. Or, if sensitive data is being written to external storage, verify that the crypto implementation meets the [baseline crypto requirements](#22-crypto).
 
 
 
 
 ### 1.1.2 The app prevents leakage of sensitive data
 
-**Description**
+#### Description
 
 This control covers unintentional data leaks where the developer actually has a way to prevent it.
 
-**Rationale**
+#### Rationale
 
-There are cases when sensitive data is unintentionally stored or exposed to publicly accessible locations; typically as a side-effect of using certain APIs, system capabilities such as backups or logs. 
+There are cases when sensitive data is unintentionally stored or exposed to publicly accessible locations; typically as a side-effect of using certain APIs, system capabilities such as backups or logs.
 
-**Audit**
+#### Audit
 
-**1.1.2.1 The Keyboard Cache Is Disabled for sensitive data inputs.**
+##### 1.1.2.1 The Keyboard Cache Is Disabled for sensitive data inputs.
 
 **Evidence**
 
-L1: Provide a code snippet showing the use of InputMethodManager showSoftInput with the SHOW_IMPLICIT flag for sensitive data fields.  
+L1: Provide a code snippet showing the use of InputMethodManager showSoftInput with the SHOW_IMPLICIT flag for sensitive data fields.
 
 **Test Procedure**
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0006](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-STORAGE/MASTG-TEST-0006.md).
 
@@ -287,35 +231,27 @@ _L2_
 
 _L1_
 
-
-
-1. Documentation does not suggest data on text inputs that process sensitive data. 
+1. Documentation does not suggest data on text inputs that process sensitive data.
 
 _L2_
 
-
-
-1. Output of the analysis shows that the app disables the keyboard cache for any sensitive data inputs. 
+1. Output of the analysis shows that the app disables the keyboard cache for any sensitive data inputs.
 
 
 
-**1.1.2.2 No sensitive data is stored in system logs**
+##### 1.1.2.2 No sensitive data is stored in system logs
 
 **Evidence**
 
-L1: Provide a sample output of all the logs in your system logs that your app outputs though an average app session. 
+L1: Provide a sample output of all the logs in your system logs that your app outputs though an average app session.
 
 **Test Procedure**
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1. Follow the testing procedures outlined in [MASTG-TEST-0003](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-STORAGE/MASTG-TEST-0003.md).
 
@@ -323,13 +259,9 @@ _L2_
 
 _L1_
 
-
-
 1. Documentation review shows or states that no sensitive data is stored in plaintext in the system logs.
 
 _L2_
-
-
 
 1. Output of the analysis shows that no sensitive data is stored in plaintext.  The scope of this test is limited to logcat and storing any logs in public locations in external storage.
 
@@ -339,17 +271,17 @@ _L2_
 
 ### 1.2.1 The app employs current strong cryptography and uses it according to industry best practices
 
-**Description**
+#### Description
 
 This control covers general cryptography best practices, which are typically defined in external standards.  For testing, the Crypto requirements only apply to sensitive data stored outside of the application sandbox.
 
-**Rationale**
+#### Rationale
 
 Cryptography plays an especially important role in securing the user's data - even more so in a mobile environment, where attackers having physical access to the user's device is a likely scenario.
 
-**Audit**
+#### Audit
 
-**1.2.1.1 No insecure random number generators shall be utilized for any security sensitive context.**
+##### 1.2.1.1 No insecure random number generators shall be utilized for any security sensitive context.
 
 **Evidence**
 
@@ -359,31 +291,23 @@ L1: If your application leverages random number generators, provide an output de
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
 
-
-
 1.  Follow the testing procedures outlined in [MASTG-TEST-0016](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-CRYPTO/MASTG-TEST-0016.md).
 
-**Verification **
+**Verification**
 
 _L1_
-
-
 
 1. Developer evidence demonstrates that for security sensitive contexts only java.security.SecureRandom is used. For non-Java-based developer evidence demonstrates that for security-sensitive contexts, only kernel-based cryptographically-secure pseudorandom number generators are used.
 
 _L2_
 
-
-
 1. Output of the analysis shows that no insecure random number generators are utilized for any security sensitive context.
 
-**1.2.1.2 No insecure operations shall be used for symmetric cryptography.**
+##### 1.2.1.2 No insecure operations shall be used for symmetric cryptography.
 
 **Evidence**
 
@@ -393,13 +317,9 @@ _L1: _If your application leverages symmetric cryptography, provide an output fr
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0013](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-CRYPTO/MASTG-TEST-0013.md).
 
@@ -407,25 +327,18 @@ _L2_
 
 _L1_
 
-
-
-1. Developer evidence demonstrates that no insecure methods shall be used for symmetric cryptography as defined below. 
+1. Developer evidence demonstrates that no insecure methods shall be used for symmetric cryptography as defined below.
 
 _L2_
 
+1. Output of the analysis shows that the app utilizes a minimum of AES-128 and that no insecure methods shall be used for symmetric cryptography as defined below unless specifically required for backwards compatibility with third party systems. Industry best practices are commonly defined as:
+   * Verify that only cryptographic primitives approved by relevant industry or government standards are in use.
+   * Verify that contexts requiring confidentiality use an approved block cipher or stream cipher.
+   * Verify that contexts requiring integrity protection use an approved MAC or digital signature algorithm.
+   * Verify that contexts requiring both confidentiality and integrity protection use an approved AEAD cipher mode.
 
 
-1. Output of the analysis shows that the app utilizes a minimum of AES-128 and that no insecure methods shall be used for symmetric cryptography as defined below unless specifically required for backwards compatibility with third party systems.
-
-    Industry best practices are commonly defined as:
-
-*   Verify that only cryptographic primitives approved by relevant industry or government standards are in use.
-*   Verify that contexts requiring confidentiality use an approved block cipher or stream cipher.
-*   Verify that contexts requiring integrity protection use an approved MAC or digital signature algorithm.
-*   Verify that contexts requiring both confidentiality and integrity protection use an approved AEAD cipher mode.
-
-
-**1.2.1.3 Strong cryptography shall be implemented according to industry best practices.**
+##### 1.2.1.3 Strong cryptography shall be implemented according to industry best practices.
 
 **Evidence**
 
@@ -435,13 +348,9 @@ L1: If your application implements cryptography, provide an output of all instan
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0014](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-CRYPTO/MASTG-TEST-0014.md). If the application is relying on non-platform provided crypto, the crypto shall be independently reviewed for security.
 
@@ -449,59 +358,46 @@ _L2_
 
 _L1_
 
-
-
 1. Developer evidence demonstrates that strong cryptography shall be implemented according to industry best practices.
 
 _L2_
 
+1. Output of the analysis shows that strong cryptography shall be implemented according to industry best practices. Industry best practices are commonly defined as:.
 
-
-1. Output of the analysis shows that strong cryptography shall be implemented according to industry best practices.
-
-    Industry best practices are commonly defined as:.
-
-*   Verify that only cryptographic primitives approved by relevant industry or government standards are in use.
-*   Verify that contexts requiring confidentiality use an approved block cipher or stream cipher.
-*   Verify that contexts requiring integrity protection use an approved MAC or digital signature algorithm.
-*   Verify that contexts requiring both confidentiality and integrity protection use an approved AEAD cipher mode.
+   * Verify that only cryptographic primitives approved by relevant industry or government standards are in use.
+   * Verify that contexts requiring confidentiality use an approved block cipher or stream cipher.
+   * Verify that contexts requiring integrity protection use an approved MAC or digital signature algorithm.
+   * Verify that contexts requiring both confidentiality and integrity protection use an approved AEAD cipher mode.
 
 
 ### 1.2.2 The app performs key management according to industry best practices
 
-**Description**
+#### Description
 
 This control covers the management of cryptographic keys throughout their lifecycle, including key generation, storage and protection. Crypto requirements only apply to sensitive data stored outside of the application sandbox.
 
-**Rationale**
+#### Rationale
 
 Even the strongest cryptography would be compromised by poor key management.
 
-**Audit**
+#### Audit
 
-**1.2.2.1 Cryptographic keys shall only be used for their defined purpose. **
+##### 1.2.2.1 Cryptographic keys shall only be used for their defined purpose.
 
 **Evidence**
 
 L1:  Provide design documentation for how crypto keys are used. For each identified instance the documentation should address the following:
-
-
-
-*   For encryption/decryption - to ensure data confidentiality
-*   For signing/verifying - to ensure integrity of data (as well as accountability in some cases)
-*   For maintenance - to protect keys during certain sensitive operations (such as being imported to the KeyStore)
+   * For encryption/decryption - to ensure data confidentiality
+   * For signing/verifying - to ensure integrity of data (as well as accountability in some cases)
+   * For maintenance - to protect keys during certain sensitive operations (such as being imported to the KeyStore)
 
 **Test Procedure**
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0015](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-CRYPTO/MASTG-TEST-0015.md)
 
@@ -509,43 +405,32 @@ _L2_
 
 _L1_
 
-
-
 1. Developer evidence demonstrates that cryptographic keys shall only be used for their defined purpose.
 
 _L2_
 
-
-
 1. Output of the analysis shows that cryptographic keys shall only be used for their defined purpose.
 
 
-**1.2.2.2  Cryptographic key management shall be implemented properly.**
+##### 1.2.2.2  Cryptographic key management shall be implemented properly.
 
 **Evidence**
 
 L1: Provide design documentation that addresses the following criteria:
-
-
-
-*   keys are not synchronized over devices if it is used to protect high-risk data.
-*   keys are not stored without additional protection.
-*   keys are not hardcoded.
-*   keys are not derived from stable features of the device.
-*   keys are not hidden by use of lower level languages (e.g. C/C++).
-*   keys are not imported from unsafe locations.
+   *   keys are not synchronized over devices if it is used to protect high-risk data.
+   *   keys are not stored without additional protection.
+   *   keys are not hardcoded.
+   *   keys are not derived from stable features of the device.
+   *   keys are not hidden by use of lower level languages (e.g. C/C++).
+   *   keys are not imported from unsafe locations.
 
 **Test Procedure**
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0062](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-CRYPTO/MASTG-TEST-0062.md)
 
@@ -553,13 +438,9 @@ _L2_
 
 _L1_
 
-
-
 1. Developer evidence demonstrates that cryptographic key management shall be implemented properly.
 
 _L2_
-
-
 
 1. Output of the analysis shows that cryptographic key management shall be implemented properly.
 
@@ -569,17 +450,17 @@ _L2_
 
 ### 1.3.1 The app uses secure authentication and authorization protocols and follows the relevant best practices
 
-**Description**
+#### Description
 
 Most apps connecting to a remote endpoint require user authentication and also enforce some kind of authorization. While the enforcement of these mechanisms must be on the remote endpoint, the apps also have to ensure that it follows all the relevant best practices to ensure a secure use of the involved protocols.
 
-**Rationale**
+#### Rationale
 
 Authentication and authorization provide an added layer of security and help prevent unauthorized access to sensitive user data.
 
-**Audit**
+#### Audit
 
-**1.3.1.1 If using OAuth 2.0 for authorization, or if using OpenID Connect for authentication, Proof Key for Code Exchange (PKCE) shall be implemented to protect the code grant.**
+##### 1.3.1.1 If using OAuth 2.0 for authorization, or if using OpenID Connect for authentication, Proof Key for Code Exchange (PKCE) shall be implemented to protect the code grant.
 
 **Evidence**
 
@@ -589,13 +470,9 @@ L1: If your application utilizes OAuth 2.0, demonstrate the use of PKCE by eithe
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Run static and dynamic analysis to ensure that PKCE is being utilized.
 
@@ -603,13 +480,9 @@ _L2_
 
 _L1_
 
-
-
 1. Developer evidence demonstrates that if the developer is using OAuth 2.0, PKCE is implemented to protect the code grant.
 
 _L2_
-
-
 
 1. Output of the analysis shows that if the developer is using OAuth 2.0, PKCE is implemented to protect the code grant.
 
@@ -619,17 +492,17 @@ _L2_
 
 ### 1.4.1 The app secures all network traffic according to the current best practices
 
-**Description**
+#### Description
 
 This control ensures that the app is in fact setting up secure connections in any situation. This is typically done by encrypting data and authenticating the remote endpoint, as TLS does. However, there are many ways for a developer to disable the platform secure defaults, or bypass them completely by using low-level APIs or third-party libraries.
 
-**Rationale**
+#### Rationale
 
-Ensuring data privacy and integrity of any data in transit is critical for any app that communicates over the network. 
+Ensuring data privacy and integrity of any data in transit is critical for any app that communicates over the network.
 
-**Audit**
+#### Audit
 
-**1.4.1.1 Network connections shall be encrypted.**
+##### 1.4.1.1 Network connections shall be encrypted.
 
 **Evidence**
 
@@ -639,13 +512,9 @@ L1: Attachment of the Android Manifest and the network-security-config XML files
 
 _L1_
 
-
-
-1. Follow the testing procedures outlined in [MASTG-TEST-0019](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-NETWORK/MASTG-TEST-0019.md) that are applicable to Android manifest and network security config. 
+1. Follow the testing procedures outlined in [MASTG-TEST-0019](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-NETWORK/MASTG-TEST-0019.md) that are applicable to Android manifest and network security config.
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0019](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-NETWORK/MASTG-TEST-0019.md)
 
@@ -653,26 +522,22 @@ _L2_
 
 _L1_
 
-
-
 1. The Android Manifest is not configured to allow plaintext connections. If it is, verify that valid justification has been provided.
 2. Using developer design documentation, verify that plaintext connections are not used over the internet for security sensitive purposes.
 
 _L2_
 
-
-
-1. Verify that the application does not use plaintext network connections over the internet for security sensitive purposes. 
+1. Verify that the application does not use plaintext network connections over the internet for security sensitive purposes.
 
     The following are out of scope:
 
-*   Connections that are not used for security sensitive purposes (e.g. anonymized analytics)
-*   Connections initiated in WebViews to navigate to arbitrary user-selected URLs, for apps that have browser capabilities.
-*   Connections to on-device web-server within the application
-*   Connections to local network web server (e.g. IoT) 
+   *   Connections that are not used for security sensitive purposes (e.g. anonymized analytics)
+   *   Connections initiated in WebViews to navigate to arbitrary user-selected URLs, for apps that have browser capabilities.
+   *   Connections to on-device web-server within the application
+   *   Connections to local network web server (e.g. IoT)
 
 
-**1.4.1.2 TLS configuration of network connections shall adhere to industry best practices.**
+##### 1.4.1.2 TLS configuration of network connections shall adhere to industry best practices.
 
 **Evidence**
 
@@ -682,13 +547,9 @@ L1: If 3rd party networking libraries are used, provide design documentation des
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1. Follow the testing procedures outlined in [MASTG-TEST-0020](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-NETWORK/MASTG-TEST-0020.md) to intercept network traffic.
 
@@ -696,31 +557,27 @@ _L2_
 
 _L1_
 
-
-
 1. Verify using design documentation that the app negotiates the best available ciphersuite that the backend offers
 2. Verify using design documentation  that the app cannot negotiate to use known vulnerable ciphers
-3. Verify using design documentation that the app uses industry best practices related to algorithms & ciphers  
+3. Verify using design documentation that the app uses industry best practices related to algorithms & ciphers
 
 _L2_
 
-
-
 1. Verify that the app negotiates the best available ciphersuite that the backend offers
 2. Verify that the app cannot negotiate to use known vulnerable ciphers
-3. Verify that the app uses industry best practices related to algorithms & ciphers 
+3. Verify that the app uses industry best practices related to algorithms & ciphers
 
     This test is limited in scope to the mobile app; not the backend.
 
 
-    For industry best practices, see section “Minimum Requirements for TLS Clients” in [SP.800-52r2](https://csrc.nist.gov/pubs/sp/800/52/r2/final) and [BSI TR-02102-2](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=6): 
+    For industry best practices, see section “Minimum Requirements for TLS Clients” in [SP.800-52r2](https://csrc.nist.gov/pubs/sp/800/52/r2/final) and [BSI TR-02102-2](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=6):
 
-*   Clients must support TLS1.2 or higher 
-*   Clients must not support SSL2.0 or SSL3.0.
-*   Clients must not default to TLS1.0 or TLS1.1
+   *   Clients must support TLS1.2 or higher
+   *   Clients must not support SSL2.0 or SSL3.0.
+   *   Clients must not default to TLS1.0 or TLS1.1
 
 
-**1.4.1.3 Endpoint identity shall be verified on network connections.**
+##### 1.4.1.3 Endpoint identity shall be verified on network connections.
 
 **Evidence**
 
@@ -730,13 +587,9 @@ L1: Attachment of Android Manifest and Network Security Config. If 3rd party net
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0021](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-NETWORK/MASTG-TEST-0021.md)
 
@@ -744,17 +597,13 @@ _L2_
 
 _L1_
 
-
-
 1. Verify that the application targets SDK > 24 or higher and user certificates are not trusted for connections that can carry sensitive data.
 2. If 3rd party networking libraries are used, verify via design documentation that user certificates are not trusted and hostname verification is enabled.
 
 _L2_
 
-
-
 1. Verify that network connections carrying sensitive data are using trusted certificates and the connection is correctly validated as per  [MASTG-TEST-0021](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-NETWORK/MASTG-TEST-0021.md)
-    *   Verify that the app does not trust user installed certificates. 
+    *   Verify that the app does not trust user installed certificates.
     *   If the system trusted CA store is not used, alternative mechanisms to validate trust such as certificate pinning may be used.
 
     This test is limited in scope to connections that contain sensitive data.
@@ -766,17 +615,17 @@ _L2_
 
 ### 1.5.1 The app uses IPC mechanisms securely
 
-**Description**
+#### Description
 
 This control ensures that all interactions involving IPC mechanisms happen securely.
 
-**Rationale**
+#### Rationale
 
 Apps typically use platform provided IPC mechanisms to intentionally expose data or functionality. Both installed apps and the user are able to interact with the app in many different ways.
 
-**Audit**
+#### Audit
 
-**1.5.1.1 The app shall limit content provider exposure and harden queries against injection attacks.**
+##### 1.5.1.1 The app shall limit content provider exposure and harden queries against injection attacks.
 
 **Evidence**
 
@@ -786,13 +635,9 @@ L1: Attachment of the Android Manifest. If a content provider is exposed, a scre
 
 _L1_
 
-
-
 1.  Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0007](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-PLATFORM/MASTG-TEST-0007.md) and provide output
 
@@ -800,18 +645,14 @@ _L2_
 
 _L1_
 
-
-
 1. Android Manifest shall demonstrate the limited necessary exposure of content providers.
 2. Design document shall demonstrate hardening measures against queries.
 
 _L2_
 
-
-
 1.  Testing output shall demonstrate limited content provider exposure, and hardening measures protecting against injection attacks.
 
-**1.5.1.2 The app shall use verified links and sanitize all link input data.**
+##### 1.5.1.2 The app shall use verified links and sanitize all link input data.
 
 **Evidence**
 
@@ -821,33 +662,25 @@ L1: Attachment of the Android Manifest. If Android API 31 and below are used, a 
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
 
-
-
 1. Follow the testing procedures outlined in [MASTG-TEST-0028](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-PLATFORM/MASTG-TEST-0028.md), with the understanding that sampling must be used given scope of test.
-2. Run the Android "App Link Verification Tester" script. 
+2. Run the Android "App Link Verification Tester" script.
 
 **Verification**
 
 _L1_
 
-
-
 1. Android Manifest demonstrates that the app target API level is above API 31, otherwise the design documentation screenshot demonstrates a sanitizing process for working with trusted inputs.
 
 _L2_
 
-
-
 1. Output from Android "App Link Verification Tester" script shall verify that all links demonstrate input sanitization.
 
 
-**1.5.1.3 Any sensitive functionality exposed via IPC shall be intentional and at the minimum required level.**
+##### 1.5.1.3 Any sensitive functionality exposed via IPC shall be intentional and at the minimum required level.
 
 **Evidence**
 
@@ -857,13 +690,9 @@ L1: Attachment of the Android Manifest with justifications for exposure and perm
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0029](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-PLATFORM/MASTG-TEST-0029.md)
 
@@ -871,19 +700,15 @@ _L2_
 
 _L1_
 
-
-
 1. Enumerate IPC mechanisms via AndroidManifest.xml to evaluate the security policy of exposed surface area available to other apps.
 
 _L2_
-
-
 
 1. There shall be no leaked sensitive information from exposed sensitive functionality.
 2. Sensitive functionality shall adhere to the principle of least privilege.
 
 
-**1.5.1.4 All Pending Intents shall be immutable or otherwise justified for mutability.**
+##### 1.5.1.4 All Pending Intents shall be immutable or otherwise justified for mutability.
 
 **Evidence**
 
@@ -893,13 +718,9 @@ L1: Attachment of the Android Manifest. If API level is below 31, screenshot fro
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0030](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-PLATFORM/MASTG-TEST-0030.md)
 
@@ -907,14 +728,10 @@ _L2_
 
 _L1_
 
-
-
 1. Android Manifest shall use API level 31 or greater to ensure immutable by default PendingIntents being in place.
 2. Or, verify the developer provided justification aligns with security tradeoffs required.
 
 _L2_
-
-
 
 1. Ensure that Pending Intents are immutable, and the app explicitly specifies the exact package, action, and component that receives the base intent.
 2. [Reference DAC documentation: https://developer.android.com/privacy-and-security/risks/pending-intent](https://developer.android.com/privacy-and-security/risks/pending-intent)
@@ -922,17 +739,17 @@ _L2_
 
 ### 1.5.2 The app uses WebViews securely.
 
-**Description**
+#### Description
 
 This control ensures that WebViews are configured securely to prevent sensitive data leakage as well as sensitive functionality exposure (e.g. via JavaScript bridges to native code).
 
-**Rationale**
+#### Rationale
 
 WebViews are typically used by apps that have a need for increased control over the UI. They can, however, also be exploited by attackers or other installed apps, potentially compromising the app's security.
 
-**Audit**
+#### Audit
 
-**1.5.2.1 WebViews shall securely execute JavaScript.**
+##### 1.5.2.1 WebViews shall securely execute JavaScript.
 
 **Evidence**
 
@@ -947,13 +764,9 @@ L1
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0031](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-PLATFORM/MASTG-TEST-0031.md)
 
@@ -961,14 +774,10 @@ _L2_
 
 _L1_
 
-
-
 1. Output from semgrep rules shall demonstrate JavaScript is disabled.
 2. If JavaScript is required the corresponding data flow diagram shall demonstrate developer controlled resource usage.
 
 _L2_
-
-
 
 1. Ensure that all endpoints use HTTPS (or other encrypted protocols) for connections.
 2. Ensure that JS and HTML are loaded locally from within the app, or from trusted web servers only.
@@ -976,13 +785,11 @@ _L2_
 4. [Refer to DAC guidance for scoping: https://developer.android.com/privacy-and-security/risks/unsafe-uri-loading](https://developer.android.com/privacy-and-security/risks/unsafe-uri-loading)
 
 
-**1.5.2.2 WebView shall be configured to allow the minimum set of protocol handlers required while disabling potentially dangerous handlers.**
+##### 1.5.2.2 WebView shall be configured to allow the minimum set of protocol handlers required while disabling potentially dangerous handlers.
 
 **Evidence**
 
 _L1_
-
-
 
 1. Provide Android Manifest for API level verification for hardening WebView defaults. If API level has a default permissive posture for file access, or file access controls have been changed to be more open, the developer must provide justification.
 2. Run [MSTG-PLATFORM-6](https://github.com/mindedsecurity/semgrep-rules-android-security/blob/main/status.md) and provide output to verify WebView usage is adhering to [MASTG-TEST-0032](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-PLATFORM/MASTG-TEST-0032.md) Static Analysis testing is configured accordingly.
@@ -992,13 +799,9 @@ _L1_
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0032](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-PLATFORM/MASTG-TEST-0032.md)
 
@@ -1006,15 +809,11 @@ _L2_
 
 _L1_
 
-
-
 1. Android Manifest shall demonstrate API level 30 or above. If API level 29 or below is in use, `setAllowFileAccess` shall be set to `false`. If `setAllowFileAccess` is set to true, developer justification must demonstrate requirement for this configuration.
 2. Output from [MSTG-PLATFORM-6](https://github.com/mindedsecurity/semgrep-rules-android-security/blob/main/status.md) shall demonstrate the usage of only necessary protocol handlers.
 3. Output from [MSTG-PLATFORM-6](https://github.com/mindedsecurity/semgrep-rules-android-security/blob/main/status.md) shall demonstrate potentially dangerous handlers such as `file`, `tel`, and `app-id` are disabled. For any potentially dangerous handlers, the developer justification must demonstrate the need for implementation.
 
 _L2_
-
-
 
 1. Output from [MSTG-PLATFORM-6](https://github.com/mindedsecurity/semgrep-rules-android-security/blob/main/status.md) shall demonstrate the usage of only necessary protocol handlers.
 2. Output from [MSTG-PLATFORM-6](https://github.com/mindedsecurity/semgrep-rules-android-security/blob/main/status.md) shall demonstrate that potentially dangerous handlers such as `file`, `tel`, and `app-id` are disabled. For any potentially dangerous handlers, the developer justification must demonstrate the need for implementation.
@@ -1023,23 +822,21 @@ _L2_
 
 ### 1.5.3 The app uses the user interface securely.
 
-**Description**
+#### Description
 
 This control ensures that this data doesn't end up being unintentionally leaked due to platform mechanisms such as auto-generated screenshots or accidentally disclosed via e.g. shoulder surfing or sharing the device with another person.
 
-**Rationale**
+#### Rationale
 
 Sensitive data has to be displayed in the UI in many situations (e.g. passwords, credit card details, OTP codes in notifications) which can lead to unintentional leaks.
 
-**Audit**
+#### Audit
 
-**1.5.3.1 The app shall by default mask data in the User Interface when it is known to be sensitive.**
+##### 1.5.3.1 The app shall by default mask data in the User Interface when it is known to be sensitive.
 
 **Evidence**
 
 _L1_
-
-
 
 1. Provide screenshots of proper input typing demonstrating that android`:inputType="textPassword"` is in use for passwords, pins, credit card information, data commonly found on government IDs (such as social security, driver ID, passport ID) fields.
 2. Show screenshots of any UI elements where passwords, pins, credit card information, data commonly found on government IDs (such as social security, driver ID, passport ID) are visible and demonstrate they are masked by default.
@@ -1048,13 +845,9 @@ _L1_
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0008](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-PLATFORM/MASTG-TEST-0008.md)
 
@@ -1062,13 +855,9 @@ _L2_
 
 _L1_
 
-
-
 1. Provided documentation shall demonstrate appropriate input type implementation for the intended use of the input field.
 
 _L2_
-
-
 
 1. Passwords, pins, credit card information, data commonly found on government IDs (such as social security, driver ID, passport ID) must be properly masked for input fields and suppressed in notifications where the app knows the type of data it is displaying.
 2. Passwords, pins, credit card information, data commonly found on government IDs (such as social security, driver ID, passport ID) shall only be displayed to the user in clear text through an explicit action, such as clicking a show password button.
@@ -1079,64 +868,56 @@ _L2_
 
 ### 1.6.1 The app requires an up-to-date platform version
 
-**Description**
+#### Description
 
 This control ensures that the app is running on an up-to-date platform version so that users have the latest security protections.
 
-**Rationale**
+#### Rationale
 
 Every release of the mobile OS includes security patches and new security features. By supporting older versions, apps stay vulnerable to well-known threats.
 
-**Audit**
+#### Audit
 
-**1.6.1.1 The app shall set the targetSdkVersion to an up-to-date platform version.**
+##### 1.6.1.1 The app shall set the targetSdkVersion to an up-to-date platform version.
 
 **Evidence**
 
-L1: Attachment of the Android Manifest 
+L1: Attachment of the Android Manifest
 
 **Test Procedure**
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
 
-
-
 1.  Obtain the Android Manifest and review for adherence with requirements
 
-**Verification **
+**Verification**
 
 _L1_
-
-
 
 1. Verify that targetSDKVersion is set to N-2 or above where N is the latest SDK at the time of test.
 
 _L2_
-
-
 
 1. Verify that the targetSdkVersion is set to N-2 or above where N is the latest SDK at the time of test.
 
 
 ### 1.6.2 The app only uses software components without known vulnerabilities
 
-**Description**
+#### Description
 
 To be truly secure, a full whitebox assessment should have been performed on all app components. However, as it usually happens with e.g. for third-party components this is not always feasible and not typically part of a penetration test. This control covers "low-hanging fruit" cases, such as those that can be detected just by scanning libraries for known vulnerabilities.
 
-**Rationale**
+#### Rationale
 
 The developer should protect users from known vulnerabilities.
 
-**Audit**
+#### Audit
 
-**1.6.2.1 The app only uses software components without known vulnerabilities.**
+##### 1.6.2.1 The app only uses software components without known vulnerabilities.
 
 **Evidence**
 
@@ -1146,13 +927,9 @@ L1: Follow the testing procedures outlined in [MASTG-TEST-0042](https://github.c
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0042](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-CODE/MASTG-TEST-0042.md)
 
@@ -1160,36 +937,32 @@ _L2_
 
 _L1_
 
-
-
-1. Verify that the app does not use any 3P libraries at a version vulnerable to a CVE with a severity >= CVSS 7.0. 
+1. Verify that the app does not use any 3P libraries at a version vulnerable to a CVE with a severity >= CVSS 7.0.
 
 _L2_
 
-
-
-1. Verify that the app does not use any 3P libraries at a version vulnerable to a CVE with a severity >= CVSS 7.0. 
+1. Verify that the app does not use any 3P libraries at a version vulnerable to a CVE with a severity >= CVSS 7.0.
 
      \
-An app that uses a 3P library at a version vulnerable to a CVE with CVSS >= 7.0 can pass this test if the developer provides additional justification that: 
+An app that uses a 3P library at a version vulnerable to a CVE with CVSS >= 7.0 can pass this test if the developer provides additional justification that:
 
-*   The app does not invoke the vulnerable 3P library code or 
-*   The 3P library has not yet made an update available. This is acceptable only if the 3P library has a regular patch process.
+   *   The app does not invoke the vulnerable 3P library code or
+   *   The 3P library has not yet made an update available. This is acceptable only if the 3P library has a regular patch process.
 
 
 ### 1.6.3 The app validates and sanitizes all untrusted inputs.
 
-**Description**
+#### Description
 
 Apps have many data entry points including the UI, IPC, the network, the file system, etc.  This control ensures that this data is treated as untrusted input and is properly verified and sanitized before it's used.
 
-**Rationale**
+#### Rationale
 
 This incoming data might have been inadvertently modified by untrusted actors and may lead to bypass of critical security checks as well as classical injection attacks such as SQL injection, XSS or insecure deserialization.
 
-**Audit**
+#### Audit
 
-**1.6.3.1 Compiler security features shall be enabled.**
+##### 1.6.3.1 Compiler security features shall be enabled.
 
 **Evidence**
 
@@ -1199,13 +972,9 @@ L1: Follow the instructions outlined in [MASTG-TEST-0044](https://github.com/OWA
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0044](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-CODE/MASTG-TEST-0044.md)
 
@@ -1213,13 +982,9 @@ _L2_
 
 _L1_
 
-
-
 1. Developer evidence demonstrates that compiler security features (PIE/PIC and stack smashing protections) are enabled.
 
 _L2_
-
-
 
 1. Output of the analysis shows that demonstrates that compiler security features (PIE/PIC and stack smashing protections) are enabled
 
@@ -1227,7 +992,7 @@ _L2_
 If a native 3P library that is packaged in the application does not have these enabled, this test can still pass if the developer provides justification that the 3P library does not build or work as expected if these are enabled.
 
 
-**1.6.3.2 The App shall Mitigate Against Injection Flaws in Content Providers.**
+##### 1.6.3.2 The App shall Mitigate Against Injection Flaws in Content Providers.
 
 **Evidence**
 
@@ -1237,13 +1002,9 @@ L1: Attachment of the Android Manifest. If a content provider is exposed, a scre
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0025](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-CODE/MASTG-TEST-0025.md)
 
@@ -1251,24 +1012,18 @@ _L2_
 
 _L1_
 
-
-
 1. Android Manifest shall demonstrate the limited necessary exposure of content providers.
 2. Design document shall demonstrate hardening measures against queries.
 
 _L2_
 
-
-
 1. Testing output shall demonstrate limited content provider exposure, and hardening measures protecting against injection attacks.
 
-**1.6.3.3 Arbitrary URL redirects shall not be included in the app's webviews**
+##### 1.6.3.3 Arbitrary URL redirects shall not be included in the app's webviews
 
 **Evidence**
 
 _L1_
-
-
 
 1. Grep output that WebView is never used as well as an attachment of the Android Manifest (or)
 2. Documentation demonstrating that only trusted content can be loaded in the apps webview
@@ -1277,52 +1032,40 @@ _L1_
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
 
-
-
 1.  Follow the testing procedures outlined in [MASTG-TEST-0027](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-CODE/MASTG-TEST-0027.md)
 
-**Verification **
+**Verification**
 
 _L1_
-
-
 
 1. Verify SafeBrowsing is enabled
 
 _L2_
 
-
-
-1. Verify that only trusted content can be loaded in the app webview: 
-*   Verify that the app correctly validates the scheme and host parts of loaded URIs against an allowlist relevant to the app, as per [unsafe-uri-loading](https://developer.android.com/privacy-and-security/risks/unsafe-uri-loading). 
-*   Verify SafeBrowsing is enabled 
+1. Verify that only trusted content can be loaded in the app webview:
+   *   Verify that the app correctly validates the scheme and host parts of loaded URIs against an allowlist relevant to the app, as per [unsafe-uri-loading](https://developer.android.com/privacy-and-security/risks/unsafe-uri-loading).
+   *   Verify SafeBrowsing is enabled
 
     If the app has no webviews, this test should pass automatically.
 
 
-**1.6.3.4 Any use of implicit intents shall be appropriate for the app's functionality and any return data shall be handled securely.**
+##### 1.6.3.4 Any use of implicit intents shall be appropriate for the app's functionality and any return data shall be handled securely.
 
 **Evidence**
 
-L1: Attach the Android Manifest and an explanation of the rationale for every implicit intent. 
+L1: Attach the Android Manifest and an explanation of the rationale for every implicit intent.
 
 **Test Procedure**
 
 _L1_
 
-
-
 1. Review all implicit intents and ensure rationale validates appropriateness for the apps functionality.
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0026](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-CODE/MASTG-TEST-0026.md)
 
@@ -1330,13 +1073,9 @@ _L2_
 
 _L1_
 
-
-
 1. Developer evidence demonstrates that the app either has no implicit intents or that the implicit intents are appropriate for the apps functionality.
 
 _L2_
-
-
 
 1. Verify that any use of implicit intents to send data to other apps is appropriate for the app’s functionality and does not leak sensitive data.
 2. Verify that after calling startActivityForResult() any data returned by other apps is handled securely within onActivityResult()
@@ -1347,17 +1086,17 @@ _L2_
 
 ### 1.7.1 The app implements anti-tampering mechanisms
 
-**Description**
+#### Description
 
 This control tries to ensure the integrity of the app's intended functionality by preventing modifications to the original code and resources.
 
-**Rationale**
+#### Rationale
 
 Apps run on a user-controlled device, and without proper protections it's relatively easy to run a modified version locally (e.g. to cheat in a game, or enable premium features without paying), or upload a backdoored version of it to third-party app stores.
 
-**Audit**
+#### Audit
 
-**1.7.1.1 The app shall be properly signed.**
+##### 1.7.1.1 The app shall be properly signed.
 
 **Evidence**
 
@@ -1367,13 +1106,9 @@ L1: Run the apksigner utility as documented in [MASTG-TEST-0038](https://github.
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0038](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-RESILIENCE/MASTG-TEST-0038.md).
 
@@ -1381,30 +1116,26 @@ _L2_
 
 _L1_
 
-
-
-1. Developer evidence demonstrates that the app is signed using v2 or higher. 
+1. Developer evidence demonstrates that the app is signed using v2 or higher.
 
 _L2_
 
-
-
-1. Output of the analysis shows that the app is signed using v2 or higher. 
+1. Output of the analysis shows that the app is signed using v2 or higher.
 
 
 ### 1.7.2 The app implements anti-static analysis mechanisms
 
-**Description**
+#### Description
 
 This control tries to impede comprehension by making it as difficult as possible to figure out how an app works using static analysis.
 
-**Rationale**
+#### Rationale
 
 Understanding the internals of an app is typically the first step towards tampering with it.
 
-**Audit**
+#### Audit
 
-**1.7.2.1 The app shall disable all debugging symbols in the production version.**
+##### 1.7.2.1 The app shall disable all debugging symbols in the production version.
 
 **Evidence**
 
@@ -1414,13 +1145,9 @@ L1: Attach the results of semgrep rule [MSTG-CODE-3](https://github.com/mindedse
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0040](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-RESILIENCE/MASTG-TEST-0040.md).
 
@@ -1428,30 +1155,26 @@ _L2_
 
 _L1_
 
-
-
-1. Developer evidence demonstrates that debugging symbols are disabled in their production version. 
+1. Developer evidence demonstrates that debugging symbols are disabled in their production version.
 
 _L2_
-
-
 
 1. Output of the analysis shows that debugging symbols are disabled in their production version.
 
 
 ### 1.7.3 The app implements anti-dynamic analysis mechanisms
 
-**Description**
+#### Description
 
 Sometimes pure static analysis is very difficult and time consuming so it typically goes hand in hand with dynamic analysis.  This control aims to make it as difficult as possible to perform dynamic analysis, as well as prevent dynamic instrumentation which could allow an attacker to modify the code at runtime.
 
-**Rationale**
+#### Rationale
 
-Observing and manipulating an app during runtime makes it much easier to decipher its behavior. 
+Observing and manipulating an app during runtime makes it much easier to decipher its behavior.
 
-**Audit**
+#### Audit
 
-**1.7.3.1 The app shall not be debuggable if installed from outside of commercial app stores.**
+##### 1.7.3.1 The app shall not be debuggable if installed from outside of commercial app stores.
 
 **Evidence**
 
@@ -1461,13 +1184,9 @@ L1: Attach the application Android Manifest or a screenshot showing that “andr
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0039](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-RESILIENCE/MASTG-TEST-0039.md).
 
@@ -1475,13 +1194,9 @@ _L2_
 
 _L1_
 
-
-
-1.  Developer evidence demonstrates that the application is not debuggable. 
+1.  Developer evidence demonstrates that the application is not debuggable.
 
 _L2_
-
-
 
 1. Output of the analysis shows that the application is not debuggable.
 
@@ -1491,17 +1206,17 @@ _L2_
 
 ### 1.8.1 The app minimizes access to sensitive data and resources.
 
-**Description**
+#### Description
 
-Apps should only request access to the data they absolutely need for their functionality and always with informed consent from the user. This control ensures that apps practice data minimization and restricts access control.  Furthermore, apps should share data with third parties only when necessary, and this should include enforcing that third-party SDKs operate based on user consent, not by default or without it. Apps should prevent third-party SDKs from ignoring consent signals or from collecting data before consent is confirmed.  Additionally, apps should be aware of the 'supply chain' of SDKs they incorporate, ensuring that no data is unnecessarily passed down their chain of dependencies. 
+Apps should only request access to the data they absolutely need for their functionality and always with informed consent from the user. This control ensures that apps practice data minimization and restricts access control.  Furthermore, apps should share data with third parties only when necessary, and this should include enforcing that third-party SDKs operate based on user consent, not by default or without it. Apps should prevent third-party SDKs from ignoring consent signals or from collecting data before consent is confirmed.  Additionally, apps should be aware of the 'supply chain' of SDKs they incorporate, ensuring that no data is unnecessarily passed down their chain of dependencies.
 
-**Rationale**
+#### Rationale
 
 Data minimization reduces the potential impact of data breaches or leaks.  This end-to-end responsibility for data aligns with recent SBOM regulatory requirements, making apps more accountable for their data practices.
 
-**Audit**
+#### Audit
 
-**1.8.1.1 The app shall minimize access to sensitive data and resources provided by the platform.**
+##### 1.8.1.1 The app shall minimize access to sensitive data and resources provided by the platform.
 
 **Evidence**
 
@@ -1511,13 +1226,9 @@ L1: Attachment of the Android manifest showing permission requests.  Provide jus
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1. Using dynamic analysis, monitor runtime permission usage, data access patterns and third-party SDK behaviors.
 
@@ -1525,30 +1236,26 @@ _L2_
 
 _L1_
 
-
-
 1. The Android Manifest adheres to least privilege principle by only requesting permissions that are needed for its functionality
 
 _L2_
 
-
-
-1. The app adheres to least privilege principle by only requesting permissions that are needed for its functionality.  Any flagged permissions requires the developer to provide justification for app functionality. 
+1. The app adheres to least privilege principle by only requesting permissions that are needed for its functionality.  Any flagged permissions requires the developer to provide justification for app functionality.
 
 
 ### 1.8.2 The app is transparent about data collection and usage
 
-**Description**
+#### Description
 
 This control ensures that apps provide clear information about data collection, storage, and sharing practices, including any behavior a user wouldn't reasonably expect, such as background data collection. Apps should also adhere to platform guidelines on data declarations.
 
-**Rationale**
+#### Rationale
 
-Users have the right to know how their data is being used. 
+Users have the right to know how their data is being used.
 
-**Audit**
+#### Audit
 
-**1.8.2.1 The app shall be transparent about data collection and usage.**
+##### 1.8.2.1 The app shall be transparent about data collection and usage.
 
 **Evidence**
 
@@ -1558,13 +1265,9 @@ L1: Provide a URL to the app’s privacy policy.  Provide a screenshot of the Ap
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Perform a match against data practices displayed in the Data Safety Section  against data practices explicitly listed in the privacy policy.  Check for data types being transmitted over the network that aren’t declared to users.
 
@@ -1572,30 +1275,26 @@ _L2_
 
 _L1_
 
-
-
 1. Ensure the developer provides a valid privacy policy and the declarations match those in the App Store label
 
 _L2_
 
-
-
-1. All data collected should be included explicitly, either within the actual application or somewhere that can be accessed via the application.  
+1. All data collected should be included explicitly, either within the actual application or somewhere that can be accessed via the application.
 
 
 ### 1.8.3 The app offers user control over their data
 
-**Description**
+#### Description
 
 This control ensures that apps provide mechanisms for users to manage, delete, and modify their data, and change privacy settings as needed (e.g. to revoke consent). Additionally, apps should re-prompt for consent and update their transparency disclosures when they require more data than initially specified.
 
-**Rationale**
+#### Rationale
 
 Users should have control over their data.
 
-**Audit**
+#### Audit
 
-**1.8.3.1 Users shall have the ability to request their data to be deleted via an in-app mechanism.**
+##### 1.8.3.1 Users shall have the ability to request their data to be deleted via an in-app mechanism.
 
 **Evidence**
 
@@ -1605,13 +1304,9 @@ L1: Provide a screenshot that shows an in-app URL which allows users to initiate
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Review App Store label to verify existence of data deletion request mechanism.  Lab confirms availability of URL in app.
 
@@ -1632,9 +1327,9 @@ _L1 & L2 _
 
 ### 2.1.1 The app securely stores sensitive data
 
-**Audit**
+#### Audit
 
-**2.1.1.1 The app shall securely store sensitive data.**
+##### 2.1.1.1 The app shall securely store sensitive data.
 
 **Evidence**
 
@@ -1644,13 +1339,9 @@ L1: Attach screenshots of all instances of files being saved outside of the app 
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1. Follow the testing procedures outlined in [MASTG-TEST-00052](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-STORAGE/MASTG-TEST-0052.md).
 
@@ -1658,58 +1349,46 @@ _L2_
 
 _L1_
 
-
-
-1. The app does not use `UIDocumentPickerViewController`. 
-2. If sensitive data is being written to external storage, confirm the crypto implementation meets the baseline <b>>>>>>GDCALERT:undefined internal link (link text: "crypto requirements"). Did you generate a TOC?>>>>></b>[crypto requirements](#heading=h.qck736ryyi5) by reviewing the relevant screenshot from the design document.
+1. The app does not use `UIDocumentPickerViewController`.
+2. If sensitive data is being written to external storage, confirm the crypto implementation meets the baseline [crypto requirements](#heading=h.qck736ryyi5) by reviewing the relevant screenshot from the design document.
 
 _L2_
 
-
-
-1. Output of the analysis shows that the app does not write and store unencrypted and sensitive data in external storage. 
-2. If sensitive data is being written to external storage, verify that the crypto implementation meets the <b>>>>>>GDCALERT:undefined internal link (link text: "baseline crypto requirements"). Did you generate a TOC?>>>>></b>[baseline crypto requirements](#heading=h.qck736ryyi5).
+1. Output of the analysis shows that the app does not write and store unencrypted and sensitive data in external storage.
+2. If sensitive data is being written to external storage, verify that the crypto implementation meets the [baseline crypto requirements](#heading=h.qck736ryyi5).
 
 
 ### 2.1.2 The app prevents leakage of sensitive data
 
-**Audit**
+#### Audit
 
-**2.1.2.1 The Keyboard Cache shall be disabled for sensitive data inputs.**
+##### 2.1.2.1 The Keyboard Cache shall be disabled for sensitive data inputs.
 
 **Evidence**
 
-L1: Provide a code snippet showing that sensitive input fields are marked as `secureTextEntry` or that autocorrect is manually disabled with `autocorrectionType = UITextAutocorrectionTypeNo`.  
+L1: Provide a code snippet showing that sensitive input fields are marked as `secureTextEntry` or that autocorrect is manually disabled with `autocorrectionType = UITextAutocorrectionTypeNo`.
 
 **Test Procedure**
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
 
-
-
-1.   Follow the testing procedures outlined in [MASTG-TEST-0055](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-STORAGE/MASTG-TEST-0055.md) 
+1.   Follow the testing procedures outlined in [MASTG-TEST-0055](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-STORAGE/MASTG-TEST-0055.md)
 
 **Verification**
 
 _L1_
 
-
-
 1. Review the provided evidence to verify that sensitive fields will not cache keyboard input.
 
 _L2_
 
+1. Output of the analysis shows sensitive data is not present in the cache after typing into the respective text field.  Note: This only applies to input into text fields that are meant to be used for sensitive data.
 
-
-1. Output of the analysis shows sensitive data is not present in the cache after typing into the respective text field.  Note: This only applies to input into text fields that are meant to be used for sensitive data. 
-
-**2.1.2.2 No sensitive data shall be stored in system logs.**
+##### 2.1.2.2 No sensitive data shall be stored in system logs.
 
 **Evidence**
 
@@ -1719,13 +1398,9 @@ L1: Provide a sample output of all the logs in your system logs that your app ou
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in[ MASTG-TEST-0053](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-STORAGE/MASTG-TEST-0053.md)
 
@@ -1733,13 +1408,9 @@ _L2_
 
 _L1_
 
-
-
 1. Documentation review shows or states that no sensitive data is stored in plaintext in the system logs.
 
 _L2_
-
-
 
 1. Output of the analysis shows that no sensitive data is stored in plaintext in the application logs.
 
@@ -1749,25 +1420,21 @@ _L2_
 
 ### 2.2.1 The app employs current strong cryptography and uses it according to industry best practices.
 
-**Audit**
+#### Audit
 
-**2.2.1.1 No insecure random number generators shall be utilized for any security sensitive context.**
+##### 2.2.1.1 No insecure random number generators shall be utilized for any security sensitive context.
 
 **Evidence**
 
-L1: If your application leverages random number generators for security purposes, provide output demonstrating that it shall only use cryptographically-secure pseudorandom number generators. For swift and objective-c code, provide output from the semgrep rule [ios_insecure_random_no_generator](https://github.com/MobSF/mobsfscan/blob/main/mobsfscan/rules/patterns/ios/swift/swift_rules.yaml). 
+L1: If your application leverages random number generators for security purposes, provide output demonstrating that it shall only use cryptographically-secure pseudorandom number generators. For swift and objective-c code, provide output from the semgrep rule [ios_insecure_random_no_generator](https://github.com/MobSF/mobsfscan/blob/main/mobsfscan/rules/patterns/ios/swift/swift_rules.yaml).
 
 **Test Procedure**
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0063](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-CRYPTO/MASTG-TEST-0063.md)
 
@@ -1775,17 +1442,13 @@ _L2_
 
 _L1_
 
-
-
 1. Developer evidence demonstrates that insecure random number generators are not used in a security sensitive context.
 
 _L2_
 
-
-
 1. Output of the analysis shows that no insecure random number generators are utilized for any security sensitive context.
 
-**2.2.1.2 **Strong cryptography shall be implemented according to industry best practices.
+##### 2.2.1.2 **Strong cryptography shall be implemented according to industry best practices.
 
 **Evidence**
 
@@ -1795,13 +1458,9 @@ L1:  If your application implements cryptography, provide an output of all insta
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1. Follow the testing procedures outlined in [MASTG-TEST-0061](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-CRYPTO/MASTG-TEST-0061.md). If the application is relying on non-platform provided crypto, the crypto shall be independently reviewed for security.
 
@@ -1809,28 +1468,24 @@ _L2_
 
 _L1_
 
-
-
 1.  Developer evidence demonstrates that strong cryptography shall be implemented according to industry best practices.
 
 _L2_
-
-
 
 1. Output of the analysis shows that strong cryptography shall be implemented according to industry best practices.
 
     Refer to [SP.800-57p1r5](https://csrc.nist.gov/pubs/sp/800/57/pt1/r5/final) and [SP.800-131Ar2](https://csrc.nist.gov/pubs/sp/800/131/a/r2/final) with 112 bit of security as baseline:
 
-*   Hashing: SHA-224 or better 
-*   Digital signatures & public key encryption: (Key length no less than 2048 bits for factoring or 224 for ECC)
-*   Custom implementations: If the provider has a custom implementation of a library (open-source library) test is in scope, home-grown implementation requires further developer assurance.
+   *   Hashing: SHA-224 or better
+   *   Digital signatures & public key encryption: (Key length no less than 2048 bits for factoring or 224 for ECC)
+   *   Custom implementations: If the provider has a custom implementation of a library (open-source library) test is in scope, home-grown implementation requires further developer assurance.
 
 
 ### 2.2.2  The app performs key management according to industry best practices
 
-**Audit**
+#### Audit
 
-**2.2.2.1 Cryptographic keys shall only be used for their defined purpose.**
+##### 2.2.2.1 Cryptographic keys shall only be used for their defined purpose.
 
 **Evidence**
 
@@ -1838,21 +1493,17 @@ L1: Provide design documentation for how crypto keys are used. For each identifi
 
 
 
-*   For encryption/decryption - to ensure data confidentiality
-*   For signing/verifying - to ensure integrity of data (as well as accountability in some cases)
-*   For maintenance - to protect keys during certain sensitive operations (such as being imported to the KeyStore)
+   *   For encryption/decryption - to ensure data confidentiality
+   *   For signing/verifying - to ensure integrity of data (as well as accountability in some cases)
+   *   For maintenance - to protect keys during certain sensitive operations (such as being imported to the KeyStore)
 
 **Test Procedure**
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0062](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-CRYPTO/MASTG-TEST-0062.md). Use objection `ios monitor crypto `command to monitor crypto operations.
 
@@ -1860,17 +1511,13 @@ _L2_
 
 _L1_
 
-
-
-1. Developer evidence demonstrates that cryptographic keys are used for their defined purpose.  
+1. Developer evidence demonstrates that cryptographic keys are used for their defined purpose.
 
 _L2_
 
+1. Dynamic analysis demonstrates that cryptographic keys are used for their defined purpose.
 
-
-1. Dynamic analysis demonstrates that cryptographic keys are used for their defined purpose.  
-
-**2.2.2.2 Cryptographic key management shall be implemented properly.**
+##### 2.2.2.2 Cryptographic key management shall be implemented properly.
 
 **Evidence**
 
@@ -1878,24 +1525,20 @@ L1: Provide design documentation that addresses the following criteria:
 
 
 
-*   keys are not synchronized over devices if it is used to protect high-risk data.
-*   keys are not stored without additional protection.
-*   keys are not hardcoded.
-*   keys are not derived from stable features of the device.
-*   keys are not hidden by use of lower level languages (e.g. C/C++).
-*   keys are not imported from unsafe locations.
+   *   keys are not synchronized over devices if it is used to protect high-risk data.
+   *   keys are not stored without additional protection.
+   *   keys are not hardcoded.
+   *   keys are not derived from stable features of the device.
+   *   keys are not hidden by use of lower level languages (e.g. C/C++).
+   *   keys are not imported from unsafe locations.
 
 **Test Procedure**
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0062](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-CRYPTO/MASTG-TEST-0062.md). Use objection `ios monitor crypto `command to monitor crypto operations.
 
@@ -1903,15 +1546,11 @@ _L2_
 
 _L1_
 
-
-
 1. Developer evidence demonstrates that cryptographic key management shall be implemented properly.
 
 _L2_
 
-
-
-1. Output of the analysis shows that cryptographic key management shall be implemented properly. 
+1. Output of the analysis shows that cryptographic key management shall be implemented properly.
 
 
 ## 2.3 Auth
@@ -1919,9 +1558,9 @@ _L2_
 
 ### 2.3.1 The app uses secure authentication and authorization protocols and follows the relevant best practices.
 
-**Audit**
+#### Audit
 
-**2.3.1.1 If using OAuth 2.0 to authenticate, Proof Key for Code Exchange (PKCE) shall be implemented to protect the code grant.**
+##### 2.3.1.1 If using OAuth 2.0 to authenticate, Proof Key for Code Exchange (PKCE) shall be implemented to protect the code grant.
 
 **Evidence**
 
@@ -1931,13 +1570,9 @@ L1: If your application utilizes OAuth 2.0, demonstrate the use of PKCE by eithe
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Run static and dynamic analysis to ensure that PKCE is being utilized.
 
@@ -1945,13 +1580,9 @@ _L2_
 
 _L1_
 
-
-
 1. Developer evidence demonstrates that if the developer is using OAuth 2.0, PKCE is implemented to protect the code grant.
 
 _L2_
-
-
 
 1. Output of the analysis shows that if the developer is using OAuth 2.0, PKCE is implemented to protect the code grant.
 
@@ -1961,9 +1592,9 @@ _L2_
 
 ### 2.4.1 The app secures all network traffic according to the current best practices.
 
-**Audit**
+#### Audit
 
-**2.4.1.1 Network connections shall be encrypted.**
+##### 2.4.1.1 Network connections shall be encrypted.
 
 **Evidence**
 
@@ -1973,13 +1604,9 @@ L1: Attach the Info.plist that shows the App Transport Security (ATS) policy, al
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0065](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-NETWORK/MASTG-TEST-0065.md) to intercept traffic.
 
@@ -1987,25 +1614,21 @@ _L2_
 
 _L1_
 
-
-
 1. ATS is not configured to allow plaintext connections. If it is, verify that valid justification has been provided.
 2. Using developer design documentation, verify that plaintext connections are not used over the internet for security sensitive purposes.
 
 _L2_
 
-
-
-1. Verify that the application does not use plaintext network connections over the internet for security sensitive purposes. 
+1. Verify that the application does not use plaintext network connections over the internet for security sensitive purposes.
 
     Valid justification for plaintext connections:
 
-*   Connections that are not used for security sensitive purposes (e.g. transferring sensitive data)
-*   Connections initiated in webviews to navigate to arbitrary user-selected URLs, for apps that have browser capabilities.
-*   Connections to on-device web-server within the application
-*   Connections to local network web server (e.g. IoT) 
+   *   Connections that are not used for security sensitive purposes (e.g. transferring sensitive data)
+   *   Connections initiated in webviews to navigate to arbitrary user-selected URLs, for apps that have browser capabilities.
+   *   Connections to on-device web-server within the application
+   *   Connections to local network web server (e.g. IoT)
 
-**2.4.1.2 TLS configuration of network connections shall adhere to industry best practices.**
+##### 2.4.1.2 TLS configuration of network connections shall adhere to industry best practices.
 
 **Evidence**
 
@@ -2015,13 +1638,9 @@ _L1: _Attach the Info.plist that shows the App Transport Security (ATS) policy, 
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0066](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-NETWORK/MASTG-TEST-0066.md) to intercept network traffic.
 
@@ -2029,31 +1648,27 @@ _L2_
 
 _L1_
 
-
-
 1. Review the provided ATS policy to see if the app allows insecure connections.
 2. Verify using design documentation that the app negotiates the best available ciphersuite that the backend offers
 3. Verify using design documentation  that the app cannot negotiate to use known vulnerable ciphers
-4. Verify using design documentation that the app uses industry best practices related to algorithms & ciphers  
+4. Verify using design documentation that the app uses industry best practices related to algorithms & ciphers
 
 _L2_
 
-
-
 1. Verify that the app negotiates the best available ciphersuite that the backend offers using the nscurl command:  `nscurl --ats-diagnostics --verbose`
 2. Verify that the app cannot negotiate to use known vulnerable ciphers
-3. Verify that the app uses industry best practices related to algorithms & ciphers 
+3. Verify that the app uses industry best practices related to algorithms & ciphers
 
     This test is limited in scope to the mobile app; not the backend.
 
 
-    For industry best practices, see section “Minimum Requirements for TLS Clients” in [SP.800-52r2](https://csrc.nist.gov/pubs/sp/800/52/r2/final) and [BSI TR-02102-2](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=6): 
+    For industry best practices, see section “Minimum Requirements for TLS Clients” in [SP.800-52r2](https://csrc.nist.gov/pubs/sp/800/52/r2/final) and [BSI TR-02102-2](https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Publications/TechGuidelines/TG02102/BSI-TR-02102-2.pdf?__blob=publicationFile&v=6):
 
-*   Clients must support TLS1.2 or higher 
-*   Clients must not support SSL2.0 or SSL3.0.
-*   Clients must not default to TLS1.0 or TLS1.1
+   *   Clients must support TLS1.2 or higher
+   *   Clients must not support SSL2.0 or SSL3.0.
+   *   Clients must not default to TLS1.0 or TLS1.1
 
-**2.4.1.3 Endpoint identity shall be verified on network connections.**
+##### 2.4.1.3 Endpoint identity shall be verified on network connections.
 
 **Evidence**
 
@@ -2063,13 +1678,9 @@ _L1: _Attachment of Info.plist file. If 3rd party networking libraries are used,
 
 _L1_
 
-
-
-1. Review the Info.plist file for the App Transport Security configuration for adherence with requirements. 
+1. Review the Info.plist file for the App Transport Security configuration for adherence with requirements.
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0067](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-NETWORK/MASTG-TEST-0067.md)
 
@@ -2077,17 +1688,13 @@ _L2_
 
 _L1_
 
-
-
 1. If the application targets iOS 9 or higher, verify that it does not trust user certificates for connections that can carry sensitive data.
 2. If 3rd party networking libraries are used, verify via design documentation that user certificates are not trusted and hostname verification is enabled.
 
 _L2_
 
-
-
 1. Verify that network connections carrying sensitive data are using trusted certificates and the connection is correctly validated as per  [MASTG-TEST-0067](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-NETWORK/MASTG-TEST-0067.md)
-    1. Verify that the app does not trust user installed certificates. 
+    1. Verify that the app does not trust user installed certificates.
     2. If the system trusted CA store is not used, alternative mechanisms to validate trust such as certificate pinning may be used.
 
     This test is limited in scope to connections that contain sensitive data.
@@ -2099,9 +1706,9 @@ _L2_
 
 ### 2.5.1 The app uses IPC mechanisms securely.
 
-**Audit**
+#### Audit
 
-**2.5.1.1 The app shall not expose sensitive data via IPC mechanisms.**
+##### 2.5.1.1 The app shall not expose sensitive data via IPC mechanisms.
 
 **Evidence**
 
@@ -2111,13 +1718,9 @@ L1: Provide evidence of usage of IPC mechanisms listed in [MASTG-TEST-0056](http
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0056](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-PLATFORM/MASTG-TEST-0056.md)
 
@@ -2125,17 +1728,13 @@ _L2_
 
 _L1_
 
-
-
 1. Review the provided documentation to validate that the application is not performing actions on behalf of the user without user interaction.
 
 _L2_
 
-
-
 1. Perform the dynamic analysis using Frida to understand functionality that is exposed via custom url schemes and verify that the application is not performing actions on behalf of the user without user interaction.
 
-**2.5.1.2 The app shall not expose sensitive data via App Extensions.**
+##### 2.5.1.2 The app shall not expose sensitive data via App Extensions.
 
 **Evidence**
 
@@ -2151,26 +1750,22 @@ grep -nr NSExtensionPointIdentifier <Payload>.app
 
 _L1_
 
-
-
 2. Review provided evidence for adherence with requirements
 
 _L2_
 
+2.  Follow the testing procedures outlined in [MASTG-TEST-0072](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-PLATFORM/MASTG-TEST-0072.md) for identifying App Extensions.
 
+**Verification**
 
-2.  Follow the testing procedures outlined in [MASTG-TEST-0072](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-PLATFORM/MASTG-TEST-0072.md) for identifying App Extensions. 
-
-**Verification **
-
-_L1 & L2: _Review the provided information to verify:
+_L1 & L2:_ Review the provided information to verify:
 
 
 
-*   Only data types required for App Extension functionality shall be supported.
-*   The application may restrict extensions (custom keyboards)
+   *   Only data types required for App Extension functionality shall be supported.
+   *   The application may restrict extensions (custom keyboards)
 
-**2.5.1.3 The app shall not expose sensitive functionality via Custom URL Schemes.**
+##### 2.5.1.3 The app shall not expose sensitive functionality via Custom URL Schemes.
 
 **Evidence**
 
@@ -2180,13 +1775,9 @@ L1: Attach the Info.plist containing any values for CFBundleURLSchemes along wit
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0075](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-PLATFORM/MASTG-TEST-0075.md).
 
@@ -2194,33 +1785,24 @@ _L2_
 
 _L1_
 
-
-
 1. Review the provided documentation to validate that the application is not performing actions on behalf of the user without user interaction.
 
 _L2_
-
-
-
 1. Perform the dynamic analysis using Frida to understand functionality that is exposed via custom url schemes and verify that the application is not performing actions on behalf of the user without user interaction.
 
-**2.5.1.4 The app shall not expose sensitive data via UIActivity Sharing.**
+##### 2.5.1.4 The app shall not expose sensitive data via UIActivity Sharing.
 
 **Evidence**
 
-_L1 & L2: _Provide documentation on UIActivity usage.
+_L1 & L2:_ Provide documentation on UIActivity usage.
 
 **Test Procedure**
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.   Follow the testing procedures outlined in [MASTG-TEST-0071](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-PLATFORM/MASTG-TEST-0071.md)
 
@@ -2230,11 +1812,11 @@ L1 & L2: Review the provided information to verify:
 
 
 
-*   The nature of the data being shared.
-*   The inclusion of custom activities.
-*   The exclusion of certain activity types.
+   *   The nature of the data being shared.
+   *   The inclusion of custom activities.
+   *   The exclusion of certain activity types.
 
-**2.5.1.5 The app shall not use the general pasteboard for sharing sensitive information.**
+##### 2.5.1.5 The app shall not use the general pasteboard for sharing sensitive information.
 
 **Evidence**
 
@@ -2244,13 +1826,9 @@ _L1: _Attach the Info.plist file and output from the semgrep rule [ios_general_p
 
 _L1_
 
-
-
 1.  Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0073](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-PLATFORM/MASTG-TEST-0073.md) for dynamic analysis of pasteboard usage.
 
@@ -2258,19 +1836,15 @@ _L2_
 
 _L1_
 
-
-
 1. Verify in the Info.plist that the application supports a minimum version of iOS 14.0 or newer.
 2. Review the semgrep output to verify that the application is not using the general pasteboard to share sensitive information.
 
 _L2_
 
-
-
 1. Verify in the Info.plist that the application supports a minimum version of iOS 14.0 or newer.
 2. Follow the steps in [MASTG-TEST-0073](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-PLATFORM/MASTG-TEST-0073.md) to verify that the app is not automatically adding sensitive data to the general pasteboard.
 
-**2.5.1.6 The app shall not expose sensitive functionality via Universal Links.**
+##### 2.5.1.6 The app shall not expose sensitive functionality via Universal Links.
 
 **Evidence**
 
@@ -2280,36 +1854,28 @@ _L1: _Attach the values for the key `com.apple.developer.associated-domains` in 
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
 
-
-
 1.   Follow the testing procedures outlined in [MASTG-TEST-0070](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-PLATFORM/MASTG-TEST-0070.md)
 
-**Verification **
+**Verification**
 
 _L1_
-
-
 
 1. Review the provided documentation to verify that the application is not performing actions on behalf of the user without user interaction.
 
 _L2_
-
-
 
 1. Perform the dynamic analysis using Frida to understand functionality that is exposed via universal links and verify that the application is not performing actions on behalf of the user without user interaction
 
 
 ### 2.5.2 The app uses WebViews securely.
 
-**Audit**
+#### Audit
 
-**2.5.2.1 WebViews shall securely execute JavaScript.**
+##### 2.5.2.1 WebViews shall securely execute JavaScript.
 
 **Evidence**
 
@@ -2317,20 +1883,16 @@ _L1: _
 
 
 
-1. Demonstrate that JavaScript is disabled within WebView. 
+1. Demonstrate that JavaScript is disabled within WebView.
 2. If JavaScript is enabled, provide a data flow diagram with trusted end-points, secure protocols, and trust boundaries demonstrating the app's control over resources being loaded.
 
 **Test Procedure**
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0076](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-PLATFORM/MASTG-TEST-0076.md)
 
@@ -2338,20 +1900,16 @@ _L2_
 
 _L1_
 
-
-
 1. JavaScript is disabled.
 2. If JavaScript is required the corresponding data flow diagram shall demonstrate developer controlled resource usage.
 
 _L2_
 
-
-
 1. Ensure that all endpoints use HTTPS (or other encrypted protocols) for connections.
 2. Ensure that JS and HTML are loaded locally from within the app, or from trusted web servers only.
 3. Ensure that users cannot define which data-sources to load based on user input.
 
-**2.5.2.2 WebView shall be configured securely.**
+##### 2.5.2.2 WebView shall be configured securely.
 
 **Evidence**
 
@@ -2360,19 +1918,15 @@ _L1:  _
 
 
 1. Provide output from [improper_wkwebview](https://github.com/akabe1/akabe1-semgrep-rules/blob/main/ios/swift/webview/improper_wkwebview.yaml) and [insecure_webview](https://github.com/akabe1/akabe1-semgrep-rules/blob/main/ios/swift/webview/insecure_webview.yaml) to demonstrate that WebView usage is adhering to [MASTG-TEST-0077](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-PLATFORM/MASTG-TEST-0077.md)
-2. Provide a justification for WebViews that load 
+2. Provide a justification for WebViews that load
 
 **Test Procedure**
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0077](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-PLATFORM/MASTG-TEST-0077.md)
 
@@ -2380,15 +1934,11 @@ _L2_
 
 _L1_
 
-
-
 1. Output from [improper_wkwebview](https://github.com/akabe1/akabe1-semgrep-rules/blob/main/ios/swift/webview/improper_wkwebview.yaml) to demonstrate the usage of WKWebView.
-2. Output from [insecure_webview](https://github.com/akabe1/akabe1-semgrep-rules/blob/main/ios/swift/webview/insecure_webview.yaml) shall demonstrate potentially dangerous usage of deprecated UIWebView. 
+2. Output from [insecure_webview](https://github.com/akabe1/akabe1-semgrep-rules/blob/main/ios/swift/webview/insecure_webview.yaml) shall demonstrate potentially dangerous usage of deprecated UIWebView.
 3. Review justification for WebViews do not unnecessarily access or allow access to local files and content providers and the app implement best practices for WebView settings
 
 _L2_
-
-
 
 1. Follow the testing procedures in [MASTG-TEST-0077](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-PLATFORM/MASTG-TEST-0077.md) and review the Frida output.
 2. Ensure that WebViews do not unnecessarily access or allow access to local files and content providers and the app implement best practices for loading WebView content and file access.
@@ -2396,9 +1946,9 @@ _L2_
 
 ### 2.5.3 The app uses the user interface securely.
 
-**Audit**
+#### Audit
 
-**2.5.3.1 The app shall by default mask data in the User Interface when it is known to be sensitive.**
+##### 2.5.3.1 The app shall by default mask data in the User Interface when it is known to be sensitive.
 
 **Evidence**
 
@@ -2413,13 +1963,9 @@ _L1: _
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0057](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-PLATFORM/MASTG-TEST-0057.md)
 
@@ -2427,13 +1973,9 @@ _L2_
 
 _L1_
 
-
-
 1. Provided documentation shall demonstrate appropriate input type implementation for the intended use of the input field.
 
 _L2_
-
-
 
 1. Passwords, pins, credit card information, data commonly found on government IDs (such as social security, driver ID, passport ID) must be properly masked for input fields and suppressed in notifications.
 2. Passwords, pins, credit card information, data commonly found on government IDs (such as social security, driver ID, passport ID) shall only be displayed to the user in clear text through an explicit action, such as clicking a show password button.
@@ -2444,9 +1986,9 @@ _L2_
 
 ### 2.6.1 The app requires an up-to-date platform version.
 
-**Audit**
+#### Audit
 
-**2.6.1.1 The app shall target an up-to-date platform version.**
+##### 2.6.1.1 The app shall target an up-to-date platform version.
 
 **Evidence**
 
@@ -2456,26 +1998,22 @@ L1: Attach the Info.plist containing the value for `DTPlatformVersion` and `DTXc
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
 
-
-
-1. Unzip the IPA file and inspect the Info.plist to confirm the `DTPlatformVersion` and `DTXcodeBuild`  against https://xcodereleases.com/ 
+1. Unzip the IPA file and inspect the Info.plist to confirm the `DTPlatformVersion` and `DTXcodeBuild`  against https://xcodereleases.com/
 
 **Verification**
 
-_L1 & L2: _Verify that the app was built with a version of Xcode (DTXcodeBuild) that is   N-2 or above where N is the latest version of Xcode at the time of test. The DTPlatformVersion should also be N-2 where N is the most recent version of iOS at the time of the test.
+_L1 & L2:_ Verify that the app was built with a version of Xcode (DTXcodeBuild) that is   N-2 or above where N is the latest version of Xcode at the time of test. The DTPlatformVersion should also be N-2 where N is the most recent version of iOS at the time of the test.
 
 
 ### 2.6.2 The app only uses software components without known vulnerabilities.
 
-**Audit**
+#### Audit
 
-**2.6.2.1 The app shall only use software components without known vulnerabilities.**
+##### 2.6.2.1 The app shall only use software components without known vulnerabilities.
 
 **Evidence**
 
@@ -2485,27 +2023,19 @@ L1: Attach the HTML output from dependency check  `dependency-check --enableExpe
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
 
-
-
-1.  Follow the testing procedures outlined in [MASTG-TEST-0085](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-CODE/MASTG-TEST-0085.md). Specifically the Dynamic Analysis section which uses objection to list the frameworks and bundles. 
+1.  Follow the testing procedures outlined in [MASTG-TEST-0085](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-CODE/MASTG-TEST-0085.md). Specifically the Dynamic Analysis section which uses objection to list the frameworks and bundles.
 
 **Verification**
 
 _L1_
 
-
-
-1. Review the output from dependency-check to verify that the app does not use any 3P libraries that have a published vulnerability with a severity >= CVSS 7.0. 
+1. Review the output from dependency-check to verify that the app does not use any 3P libraries that have a published vulnerability with a severity >= CVSS 7.0.
 
 _L2_
-
-
 
 1. Review the output from objection to verify that the app does not use any 3P libraries that have a published vulnerability with a severity >= CVSS 7.0.
 
@@ -2516,9 +2046,9 @@ An app that uses a vulnerable 3P library can still pass this test if the develop
 
 ### 2.6.3 The app validates and sanitizes all untrusted inputs.
 
-**Audit**
+#### Audit
 
-**2.6.3.1 Compiler security features shall be enabled.**
+##### 2.6.3.1 Compiler security features shall be enabled.
 
 **Evidence**
 
@@ -2528,13 +2058,9 @@ L1: Attach the pdf report generated by [mobsf](http://mobsf.live).
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0087](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-CODE/MASTG-TEST-0087.md). Specifically the Dynamic Analysis section which uses objection to list compiler flags.
 
@@ -2542,13 +2068,9 @@ _L2_
 
 _L1_
 
-
-
 1. Verify the binary uses PIE ASLR, and stack canaries by observing the IPA BINARY ANALYSIS section of the mobsf report.
 
 _L2_
-
-
 
 1. Verify the binary uses PIE ASLR and stack canaries by observing the output from objection
 
@@ -2558,9 +2080,9 @@ _L2_
 
 ### 2.7.1 The app implements anti-tampering mechanisms.
 
-**Audit**
+#### Audit
 
-**2.7.1.1 The app shall be properly signed.**
+##### 2.7.1.1 The app shall be properly signed.
 
 **Evidence**
 
@@ -2570,28 +2092,24 @@ L1: This only applies to apps that will be distributed outside of the App Store.
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
 
-
-
-1.  Follow the testing procedures outlined in [MASTG-TEST-0081](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0081.md). 
+1.  Follow the testing procedures outlined in [MASTG-TEST-0081](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0081.md).
 
 **Verification**
 
-_L1 & L2: _Verify that the app is signed using the [latest code signature format](https://developer.apple.com/documentation/xcode/using-the-latest-code-signature-format).
+_L1 & L2:_ Verify that the app is signed using the [latest code signature format](https://developer.apple.com/documentation/xcode/using-the-latest-code-signature-format).
 
 
 ### 2.7.2 The app implements anti-static analysis mechanisms.
 
-**Audit**
+#### Audit
 
- 
 
-**2.7.2.1 The app shall disable all debugging symbols in the production version.**
+
+##### 2.7.2.1 The app shall disable all debugging symbols in the production version.
 
 **Evidence**
 
@@ -2601,36 +2119,28 @@ L1: Attach a screenshot showing that `Strip Debug Symbols During Copy` is set to
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements
 
 _L2_
 
-
-
-1.  Follow the testing procedures outlined in [MASTG-TEST-0083](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0083.md). 
+1.  Follow the testing procedures outlined in [MASTG-TEST-0083](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0083.md).
 
 **Verification**
 
 _L1_
 
-
-
-1. Developer evidence demonstrates that debugging symbols are disabled in their production version. 
+1. Developer evidence demonstrates that debugging symbols are disabled in their production version.
 
 _L2_
-
-
 
 1. Output of the analysis shows that debugging symbols are disabled in their production version.
 
 
 ### 2.7.3 The app implements anti-dynamic analysis techniques.
 
-**Audit**
+#### Audit
 
-**2.7.3.1 The app shall not be debuggable if installed from outside of commercial app stores.**
+##### 2.7.3.1 The app shall not be debuggable if installed from outside of commercial app stores.
 
 **Evidence**
 
@@ -2640,19 +2150,15 @@ L1: This only applies to apps that will be distributed outside of the App Store.
 
 _L1_
 
-
-
 1.  Review provided evidence for adherence with requirements
 
 _L2_
-
-
 
 1.  Follow the testing procedures outlined in [MASTG-TEST-0082](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0082.md) for using `codesign` to check if debugging is enabled.
 
 **Verification**
 
-_L1 & L2: _Verify that the app does not allow debugging by ensuring the value for `get-task-allow` is `false`.
+_L1 & L2:_ Verify that the app does not allow debugging by ensuring the value for `get-task-allow` is `false`.
 
 
 ## 2.8 Privacy
@@ -2660,9 +2166,9 @@ _L1 & L2: _Verify that the app does not allow debugging by ensuring the value fo
 
 ### 2.8.1 The app minimizes access to sensitive data and resources.
 
-**Audit**
+#### Audit
 
-**2.8.1.1 The app shall minimize access to sensitive data and resources provided by the platform.**
+##### 2.8.1.1 The app shall minimize access to sensitive data and resources provided by the platform.
 
 **Evidence**
 
@@ -2672,13 +2178,9 @@ L1: Attachment of the Info.plist file showing permission requests along with des
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1. Review Info.plist for adherence with requirement. Perform analysis to validate consent mechanisms upon data requests.
 
@@ -2686,22 +2188,18 @@ _L2_
 
 _L1_
 
-
-
 1. The app adheres to least privilege principle by only requesting permissions that are needed for its functionality along with descriptive descriptions.
 
 _L2_
-
-
 
 1. The app adheres to least privilege principle by only requesting permissions that are needed for its functionality  with descriptive descriptions.
 
 
 ### 2.8.2 The app is transparent about data collection and usage.
 
-**Audit**
+#### Audit
 
-**2.8.2.1 The app shall be transparent about data collection and usage.**
+##### 2.8.2.1 The app shall be transparent about data collection and usage.
 
 **Evidence**
 
@@ -2711,13 +2209,9 @@ L1: Provide a URL to the app’s privacy policy.  Provide a screenshot of the  P
 
 _L1_
 
-
-
 1. Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1. Perform a match against data practices displayed in the Privacy Nutrition labels   against data practices explicitly listed in the privacy policy.  Check for data types being transmitted over the network that aren’t declared to users.
 
@@ -2725,22 +2219,18 @@ _L2_
 
 _L1_
 
-
-
-1. Ensure the developer provides a valid privacy policy and the declarations match those in the  Privacy Nutrition labels 
+1. Ensure the developer provides a valid privacy policy and the declarations match those in the  Privacy Nutrition labels
 
 _L2_
 
-
-
-1. All data collected should be included explicitly, either within the actual application or somewhere that can be accessed via the application.  
+1. All data collected should be included explicitly, either within the actual application or somewhere that can be accessed via the application.
 
 
 ### 2.8.3 The app offers user control over their data.
 
-**Audit**
+#### Audit
 
-**2.8.3.1 Users shall have the ability to request their data to be deleted via an in-app mechanism.**
+##### 2.8.3.1 Users shall have the ability to request their data to be deleted via an in-app mechanism.
 
 **Evidence**
 
@@ -2750,16 +2240,12 @@ L1:  Provide a screenshot that shows an in-app URL which allows users to initiat
 
 _L1_
 
-
-
 1.  Review provided evidence for adherence with requirements.
 
 _L2_
-
-
 
 1.  Review App Store label to verify existence of data deletion request mechanism.  Lab confirms availability of URL in app.
 
 **Verification**
 
-_L1 & L2: _The app provides an in-app mechanism which allows users to modify and delete their personal data.
+_L1 & L2:_ The app provides an in-app mechanism which allows users to modify and delete their personal data.


### PR DESCRIPTION
Updating TOC to fix links. Previously linking to MASVS they now link to the respective section. 

Also fixed some markdown formatting.