### PR TITLE
Update network connection security verbiage

### DIFF
--- a/Mobile App Profile/Mobile App Test Guide.md
+++ b/Mobile App Profile/Mobile App Test Guide.md
@@ -547,6 +547,7 @@ The following are out of scope:
 * Connections initiated in WebViews to navigate to arbitrary user-selected URLs, for apps that have browser capabilities.
 * Connections to on-device web-server within the application
 * Connections to local network web server (e.g. IoT)
+* Unencrypted connections that have a valid justification provided.
 
 ---
 
@@ -1706,6 +1707,7 @@ Valid justification for plaintext connections:
 * Connections initiated in webviews to navigate to arbitrary user-selected URLs, for apps that have browser capabilities.
 * Connections to on-device web-server within the application
 * Connections to local network web server (e.g. IoT)
+* Unencrypted connections that have a valid justification provided.
 
 ---
 


### PR DESCRIPTION
Attestation L1 and L2 for both 1.4.1.1 and 2.4.1.1 had an L1 exception for justified plaintext connections, but L2 did not. The difference in assurance levels should convey the same level of security expectations. This change corrects the misalignment.