### PR TITLE
Fix spelling error in cloud test guide

### DIFF
--- a/Cloud App and Config Profile/Cloud App and Config Test Guide.md
+++ b/Cloud App and Config Profile/Cloud App and Config Test Guide.md
@@ -581,9 +581,9 @@ When software ceases to be supported, the maintainer of that software will no lo
 ---
 
 ### 1.2.1 Ensure that all AWS Lambda functions are configured to use a current (not deprecated) runtime
-**Platform:** AWS 
+**Platform:** AWS
 
-**Rationale:** Newer versions may contain security enhancements and additional functionality. Using the latest software version is recommended in order to take advantage of enhancements and new capabilities. With each software installation, organizations need to determine if a given update meets their requirements. They must also verify the compatibility and support provided for any additional software against the update revision that is selected. 
+**Rationale:** Newer versions may contain security enhancements and additional functionality. Using the latest software version is recommended in order to take advantage of enhancements and new capabilities. With each software installation, organizations need to determine if a given update meets their requirements. They must also verify the compatibility and support provided for any additional software against the update revision that is selected.
 
 **External Reference:** [AWS Security Hub Lambda.2](https://docs.aws.amazon.com/securityhub/latest/userguide/lambda-controls.html#lambda-2)
 
@@ -598,7 +598,7 @@ When software ceases to be supported, the maintainer of that software will no lo
 
 
 ```
-aws lambda list-functions --function-version ALL --region <region> --output text --query "Functions[?Runtime=='<RUNTIME_IDENTIFIER>'].FunctionArn" 
+aws lambda list-functions --function-version ALL --region <region> --output text --query "Functions[?Runtime=='<RUNTIME_IDENTIFIER>'].FunctionArn"
 ```
 
 
@@ -623,9 +623,9 @@ Evidence or test output indicates that no Lambda function is configured to use a
 ---
 
 ### 1.2.2 Ensure that all Azure Functions are configured to use a current (not deprecated) runtime
-**Platform:** Azure 
+**Platform:** Azure
 
-**Rationale:** Newer versions may contain security enhancements and additional functionality. Using the latest software version is recommended in order to take advantage of enhancements and new capabilities. With each software installation, organizations need to determine if a given update meets their requirements. They must also verify the compatibility and support provided for any additional software against the update revision that is selected. 
+**Rationale:** Newer versions may contain security enhancements and additional functionality. Using the latest software version is recommended in order to take advantage of enhancements and new capabilities. With each software installation, organizations need to determine if a given update meets their requirements. They must also verify the compatibility and support provided for any additional software against the update revision that is selected.
 
 **External Reference:** Todo
 
@@ -642,7 +642,7 @@ Evidence or test output indicates that all Azure Functions are:
 1. Configured to use a supported (i.e., not unsupported) runtime host version
 2. Using a language version that is not past its EOL date
 
-Microsoft documentation contains the specific dates and version for supported languages and runtime modes: https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions	 
+Microsoft documentation contains the specific dates and version for supported languages and runtime modes: https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions
 
 
 ---
@@ -755,7 +755,7 @@ Evidence or test output indicates that -- if used to run the web app -- the deve
 
 ---
 
-### 1.2.5 Ensure that 'Java version' is the latest, if used to run the Web App 
+### 1.2.5 Ensure that 'Java version' is the latest, if used to run the Web App
 **Platform:** Azure
 
 **Rationale:** Newer versions may contain security enhancements and additional functionality. Using the latest software version is recommended in order to take advantage of enhancements and new capabilities. With each software installation, organizations need to determine if a given update meets their requirements. They must also verify the compatibility and support provided for any additional software against the update revision that is selected.
@@ -809,7 +809,7 @@ Evidence or test output indicates that -- if used to run the web app -- the deve
 
 ---
 
-### 1.2.6 Ensure that 'HTTP Version' is the Latest, if Used to Run the Web App 
+### 1.2.6 Ensure that 'HTTP Version' is the Latest, if Used to Run the Web App
 **Platform:** Azure
 
 **Rationale:** Newer versions may contain security enhancements and additional functionality. Using the latest version is recommended in order to take advantage of enhancements and new capabilities. With each software installation, organizations need to determine if a given update meets their requirements. They must also verify the compatibility and support provided for any additional software against the update revision that is selected.
@@ -862,10 +862,10 @@ Evidence or test output indicates that HTTP 2.0 is enabled for each webapp.
 
 ---
 
-### 1.2.6 Ensure that all GCP Cloud functions are configured to use a current (not deprecated) runtime 
+### 1.2.6 Ensure that all GCP Cloud functions are configured to use a current (not deprecated) runtime
 **Platform:** Google
 
-**Rationale:** Newer versions may contain security enhancements and additional functionality. Using the latest software version is recommended in order to take advantage of enhancements and new capabilities. With each software installation, organizations need to determine if a given update meets their requirements. They must also verify the compatibility and support provided for any additional software against the update revision that is selected. 
+**Rationale:** Newer versions may contain security enhancements and additional functionality. Using the latest software version is recommended in order to take advantage of enhancements and new capabilities. With each software installation, organizations need to determine if a given update meets their requirements. They must also verify the compatibility and support provided for any additional software against the update revision that is selected.
 
 **External Reference:** Todo
 
@@ -893,7 +893,7 @@ Encryption protects sensitive data when transmitted over untrusted network conne
 
 ---
 
-### 1.3.1 Ensure Web App Redirects All HTTP traffic to HTTPS in Azure App Service 
+### 1.3.1 Ensure Web App Redirects All HTTP traffic to HTTPS in Azure App Service
 **Platform:** Azure
 
 **Rationale:** Enabling HTTPS-only traffic will redirect all non-secure HTTP requests to HTTPS ports. HTTPS uses the TLS/SSL protocol to provide a secure connection which is both encrypted and authenticated. It is therefore important to support HTTPS for the security benefits.
@@ -998,7 +998,7 @@ Evidence or test output indicates that each webapp is configured to require TLS 
 
 
 ---
-### 1.3.3 Ensure FTP deployments are Disabled 
+### 1.3.3 Ensure FTP deployments are Disabled
 **Platform:** Azure
 
 **Rationale:** Azure FTP deployment endpoints are public. An attacker listening to traffic on a wifi network used by a remote employee or a corporate network could see login traffic in clear-text which would then grant them full control of the code base of the app or service. This finding is more severe if User Credentials for deployment are set at the subscription level rather than using the default Application Credentials which are unique per App.
@@ -1066,7 +1066,7 @@ Evidence or test output indicates that no webapp is deployed with FtpsState of A
 
 ---
 
-### 1.3.4 Ensure “Block Project-Wide SSH Keys” Is Enabled for VM Instances 
+### 1.3.4 Ensure “Block Project-Wide SSH Keys” Is Enabled for VM Instances
 **Platform:** Google
 
 **Rationale:** Project-wide SSH keys are stored in Compute/Project-meta-data. Project wide SSH keys can be used to login into all the instances within the project. Using project-wide SSH keys eases the SSH key management but if compromised, poses the security risk which can impact all the instances within the project. It is recommended to use Instance specific SSH keys which can limit the attack surface if the SSH keys are compromised.
@@ -1230,7 +1230,7 @@ Evidence or test output indicates that no compute instance is configured with CA
 ---
 
 
-## 1.6 Manage Default Accounts on Enterprise Assets and Software 
+## 1.6 Manage Default Accounts on Enterprise Assets and Software
 ### Description
 
 Manage default accounts on enterprise assets and software, such as root, administrator, and other pre-configured vendor accounts. Example implementations can include: disabling default accounts or making them unusable.
@@ -2067,7 +2067,7 @@ For each key vault, ensure that the output of the below command contains Key ID 
 
 
 ```
-az keyvault key list --vault-name <KEYVAULTNAME> --query '[*].{"kid":kid,"enabled":attributes.enabled,"expires":attributes.expires}' 
+az keyvault key list --vault-name <KEYVAULTNAME> --query '[*].{"kid":kid,"enabled":attributes.enabled,"expires":attributes.expires}'
 ```
 
 
@@ -2383,7 +2383,7 @@ Run the following command:
 
 
 ```
-aws iam get-account-summary | grep "AccountAccessKeysPresent" 
+aws iam get-account-summary | grep "AccountAccessKeysPresent"
 ```
 
 
@@ -2450,7 +2450,7 @@ user,password_enabled,access_key_1_active,access_key_1_last_used_date,access_key
  rakesh,false,false,N/A,false,N/A
  helene,false,true,2015-11-18T17:47:00+00:00,false,N/A
  paras,true,true,2016-08-28T12:04:00+00:00,true,2016-03-04T10:11:00+00:00
- anitha,true,true,2016-06-08T11:43:00+00:00,true,N/A 
+ anitha,true,true,2016-06-08T11:43:00+00:00,true,N/A
 
 ```
 
@@ -2465,7 +2465,7 @@ Evidence or test output indicates that no user exists for which: (1) password en
 
 ---
 
-### 2.7.3 Ensure IAM policies that allow full "\*:\*" administrative privileges are not attached 
+### 2.7.3 Ensure IAM policies that allow full "\*:\*" administrative privileges are not attached
 **Platform:** AWS
 
 **Rationale:** It's more secure to start with a minimum set of permissions and grant additional permissions as necessary, rather than starting with permissions that are too lenient and then trying to tighten them later.
@@ -2508,7 +2508,7 @@ Perform the following to determine what policies are created:
 
 **Verification**
 
-Evidence or test output indicates that no customer-managed IAM policy that allows full administrative privileges are attached (i.e., in effect within the AWS account). Note that inline and AWS-manged policies are exempt from this requirement.
+Evidence or test output indicates that no customer-managed IAM policy that allows full administrative privileges are attached (i.e., in effect within the AWS account). Note that inline and AWS-managed policies are exempt from this requirement.
 
 
 ---
@@ -2873,7 +2873,7 @@ Perform the following to ensure the password policy is configured as prescribed:
 
 
 ```
-aws iam get-account-password-policy 
+aws iam get-account-password-policy
 ```
 
 
@@ -2931,7 +2931,7 @@ Ensuring that dormant accounts are disabled when they're no longer needed reduce
 
 ---
 
-### 2.10.1 Ensure credentials unused for 45 days or greater are disabled 
+### 2.10.1 Ensure credentials unused for 45 days or greater are disabled
 **Platform:** AWS
 
 **Rationale:** Disabling or removing unnecessary credentials will reduce the window of opportunity for credentials associated with a compromised or abandoned account to be used.
@@ -2993,7 +2993,7 @@ Evidence or test output indicates that no dormant credentials exist as defined b
 
 
 ---
-### 2.10.2 Ensure Guest Users Are Reviewed on a Regular Basis 
+### 2.10.2 Ensure Guest Users Are Reviewed on a Regular Basis
 **Platform:** Azure
 
 **Rationale:** Guest users in the Azure AD are generally required for collaboration purposes in Office 365, and may also be required for Azure functions in enterprises with multiple Azure tenants. Guest users are typically added outside your employee on-boarding/off-boarding process and could potentially be overlooked indefinitely, leading to a potential vulnerability. To prevent this, guest users should be reviewed on a regular basis. During this audit, guest users should also be determined to not have administrative privileges.
@@ -3272,7 +3272,7 @@ Centralizing makes administration simpler and therefore reduces risks related to
 
 ---
 
-### 2.12.1 Ensure that Corporate Login Credentials are Used 
+### 2.12.1 Ensure that Corporate Login Credentials are Used
 **Platform:** Google
 
 **Rationale:** It is recommended fully-managed corporate Google accounts be used for increased visibility, auditing, and controlling access to Cloud Platform resources. Email accounts based outside of the user's organization, such as personal accounts, should not be used for business purposes.
@@ -3295,7 +3295,7 @@ Also list the accounts added on each folder:
 
 
 ```
-gcloud resource-manager folders get-iam-policy FOLDER_ID 
+gcloud resource-manager folders get-iam-policy FOLDER_ID
 ```
 
 
@@ -3403,7 +3403,7 @@ Evidence or test output indicates that the `Number of methods required to reset 
 
 ---
 
-### 2.14.2 Ensure that 'Require Multi-Factor Authentication to register or join devices with Azure AD' is set to 'Yes' 
+### 2.14.2 Ensure that 'Require Multi-Factor Authentication to register or join devices with Azure AD' is set to 'Yes'
 **Platform:** Azure
 
 **Rationale:** Multi-factor authentication is recommended when adding devices to Azure AD. When set to `Yes`, users who are adding devices from the internet must first use the second method of authentication before their device is successfully added to the directory. This ensures that rogue devices are not added to the domain using a compromised user account. _Note:_ Some Microsoft documentation suggests using conditional access policies for joining a domain from certain whitelisted networks or devices. Even with these in place, using Multi-Factor Authentication is still recommended, as it creates a process for review before joining the domain.
@@ -3510,7 +3510,7 @@ Evidence or test output indicates that `MFA Status is `Enabled` for all privileg
 
 ---
 
-### 2.14.4 Ensure that 'Allow users to remember multi-factor authentication on devices they trust' is Disabled 
+### 2.14.4 Ensure that 'Allow users to remember multi-factor authentication on devices they trust' is Disabled
 **Platform:** Azure
 
 **Rationale:** Remembering Multi-Factor Authentication (MFA) for devices and browsers allows users to have the option to bypass MFA for a set number of days after performing a successful sign-in using MFA. This can enhance usability by minimizing the number of times a user may need to perform two-step verification on the same device. However, if an account or device is compromised, remembering MFA for trusted devices may affect security. Hence, it is recommended that users not be allowed to bypass MFA.
@@ -3537,7 +3537,7 @@ Evidence or test output indicates that `Allow users to remember MFA on devices t
 
 ---
 
-### 2.14.5 Ensure that A Multi-factor Authentication Policy Exists for All Users 
+### 2.14.5 Ensure that A Multi-factor Authentication Policy Exists for All Users
 **Platform:** Azure
 
 **Rationale:** Enabling multi-factor authentication is a recommended setting to limit the potential of accounts being compromised and limiting access to authenticated personnel.
@@ -3564,7 +3564,7 @@ Evidence or test output indicates that a MFA policy exists for all users.
 
 ---
 
-### 2.14.6 Ensure Multi-factor Authentication is Required for Risky Sign-ins 
+### 2.14.6 Ensure Multi-factor Authentication is Required for Risky Sign-ins
 **Platform:** Azure
 
 **Rationale:** Enabling multi-factor authentication is a recommended setting to limit the potential of accounts being compromised and limiting access to authenticated personnel.
@@ -3590,7 +3590,7 @@ Evidence or test output indicates that MFA is required for risky sign ins.
 
 ---
 
-### 2.14.7 Ensure that Multi-Factor Authentication is 'Enabled' for All Non-Service Accounts 
+### 2.14.7 Ensure that Multi-Factor Authentication is 'Enabled' for All Non-Service Accounts
 **Platform:** Google
 
 **Rationale:** Multi-factor authentication requires more than one mechanism to authenticate a user. This secures user logins from attackers exploiting stolen or weak credentials.
@@ -3615,7 +3615,7 @@ Evidence or test output indicates that MFA is enabled for all non service accoun
 
 ---
 
-### 2.14.8 Ensure that 'Multi-Factor Auth Status' is 'Enabled' for all Non-Privileged Users 
+### 2.14.8 Ensure that 'Multi-Factor Auth Status' is 'Enabled' for all Non-Privileged Users
 **Platform:** Azure
 
 **Rationale:** Multi-factor authentication requires an individual to present a minimum of two separate forms of authentication before access is granted. Multi-factor authentication provides additional assurance that the individual attempting to gain access is who they claim to be. With multi-factor authentication, an attacker would need to compromise at least two different authentication mechanisms, increasing the difficulty of compromise and thus reducing the risk.**
@@ -3689,7 +3689,7 @@ Requiring MFA makes it harder for malicious attackers to takeover accounts, e.g.
 
 ---
 
-### 2.15.1 Ensure that A Multi-factor Authentication Policy Exists for Administrative Groups 
+### 2.15.1 Ensure that A Multi-factor Authentication Policy Exists for Administrative Groups
 **Platform:** Azure
 
 **Rationale:** Enabling multi-factor authentication is a recommended setting to limit the use of Administrative accounts to authenticated personnel.
@@ -3760,7 +3760,7 @@ Requiring MFA makes it harder for malicious attackers to takeover accounts, e.g.
 
 ---
 
-### 2.16.1 Ensure MFA is enabled for the 'root' user account 
+### 2.16.1 Ensure MFA is enabled for the 'root' user account
 **Platform:** AWS
 
 **Rationale:** Enabling MFA provides increased security for console access as it requires the authenticating principal to possess a device that emits a time-sensitive key and have knowledge of a credential.
@@ -3883,7 +3883,7 @@ Perform the following to determine if an inline policy is set or a policy is dir
 
 
 ```
- aws iam list-users --query 'Users[*].UserName' --output text 
+ aws iam list-users --query 'Users[*].UserName' --output text
 
 ```
 
@@ -3894,7 +3894,7 @@ Perform the following to determine if an inline policy is set or a policy is dir
 
 ```
  aws iam list-attached-user-policies --user-name <iam_user>
- aws iam list-user-policies --user-name <iam_user> 
+ aws iam list-user-policies --user-name <iam_user>
 
 ```
 
@@ -3988,7 +3988,7 @@ Tools must be tuned to reduce the prevalence of both false negatives and false p
 
 ---
 
-### 3.2.1 Ensure That 'Notify about alerts with the following severity' is Set to 'High' 
+### 3.2.1 Ensure That 'Notify about alerts with the following severity' is Set to 'High'
 **Platform:** Azure
 
 **Rationale:** Enabling security alert emails ensures that security alert emails are received from Microsoft. This ensures that the right people are aware of any potential security issues and are able to mitigate the risk.
@@ -4166,7 +4166,7 @@ Perform the following ensure the CloudTrail S3 bucket has access logging is enab
 
 
 ```
-aws cloudtrail describe-trails --query 'trailList[*].S3BucketName' 
+aws cloudtrail describe-trails --query 'trailList[*].S3BucketName'
 
 ```
 
@@ -4219,7 +4219,7 @@ The principle of least privilege reduces the risk of unauthorized actions being 
 
 ---
 
-### 3.5.1 Ensure the S3 bucket used to store CloudTrail logs is not publicly accessible 
+### 3.5.1 Ensure the S3 bucket used to store CloudTrail logs is not publicly accessible
 **Platform:** AWS
 
 **Rationale:** Allowing public access to CloudTrail log content may aid an adversary in identifying weaknesses in the affected account's use or configuration.
@@ -4281,7 +4281,7 @@ Perform the following to determine if any public access is granted to an S3 buck
 
 
 ```
- aws s3api get-bucket-policy --bucket <s3_bucket_for_cloudtrail> 
+ aws s3api get-bucket-policy --bucket <s3_bucket_for_cloudtrail>
 
 ```
 
@@ -4709,7 +4709,7 @@ If you are using CloudTrails and CloudWatch, perform the following to ensure tha
 
 
 ```
-aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn> 
+aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn>
 ```
 
 
@@ -4728,7 +4728,7 @@ Evidence or test output indicates that there is at least one active multi-region
 
 ---
 
-### 3.9.2 Ensure usage of 'root' account is monitored 
+### 3.9.2 Ensure usage of 'root' account is monitored
 **Platform:** AWS
 
 **Rationale:** Monitoring for 'root' account logins will provide visibility into the use of a fully privileged account and an opportunity to reduce the use of it.
@@ -4823,7 +4823,7 @@ If you are using CloudTrails and CloudWatch, perform the following to ensure tha
 
 
    ```
-   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn> 
+   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn>
    ```
 
 
@@ -4937,7 +4937,7 @@ If you are using CloudTrails and CloudWatch, perform the following to ensure tha
 
 
    ```
-   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn> 
+   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn>
    ```
 
 
@@ -4980,7 +4980,7 @@ If you are using CloudTrails and CloudWatch, perform the following to ensure tha
 
    * Ensure Identified Multi region CloudTrail is active
 
-   
+
    ```
    aws cloudtrail get-trail-status --name <Name of a Multi-region CloudTrail>
    ```
@@ -5040,7 +5040,7 @@ If you are using CloudTrails and CloudWatch, perform the following to ensure tha
 
 
    ```
-   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn> 
+   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn>
    ```
 
 
@@ -5145,7 +5145,7 @@ If you are using CloudTrails and CloudWatch, perform the following to ensure tha
 
 
    ```
-   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn> 
+   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn>
    ```
 
 
@@ -5250,7 +5250,7 @@ If you are using CloudTrails and CloudWatch, perform the following to ensure tha
 
 
    ```
-   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn> 
+   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn>
    ```
 
 
@@ -5269,7 +5269,7 @@ Evidence or test output indicates that there is at least one active multi-region
 
 ---
 
-### 3.9.7 Ensure route table changes are monitored 
+### 3.9.7 Ensure route table changes are monitored
 **Platform:** AWS
 
 **Rationale:** CloudWatch is an AWS native service that allows you to observe and monitor resources and applications. CloudTrail Logs can also be sent to an external Security information and event management (SIEM) environment for monitoring and alerting.
@@ -5354,7 +5354,7 @@ If you are using CloudTrails and CloudWatch, perform the following to ensure tha
 7. Ensure there is at least one active subscriber to the SNS topic
 
    ```
-   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn> 
+   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn>
    ```
 
 
@@ -5459,7 +5459,7 @@ If you are using CloudTrails and CloudWatch, perform the following to ensure tha
 
 
    ```
-   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn> 
+   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn>
    ```
 
 
@@ -5567,9 +5567,9 @@ If you are using CloudTrails and CloudWatch, perform the following:
 `Note the AlarmActions value - this will provide the SNS topic ARN value.
 7. Ensure there is at least one active subscriber to the SNS topic:
 
-   
+
    ```
-   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn> 
+   aws sns list-subscriptions-by-topic --topic-arn <sns_topic_arn>
    ```
 
 
@@ -5798,11 +5798,11 @@ Evidence or test output indicates that log sinks are configured for all log entr
 
 
 ```
-(protoPayload.serviceName="cloudresourcemanager.googleapis.com") 
-AND (ProjectOwnership OR projectOwnerInvitee) 
-OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="REMOVE" 
-AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner") 
-OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="ADD" 
+(protoPayload.serviceName="cloudresourcemanager.googleapis.com")
+AND (ProjectOwnership OR projectOwnerInvitee)
+OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="REMOVE"
+AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner")
+OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="ADD"
 AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner")
 ```
 
@@ -5835,11 +5835,11 @@ gcloud logging metrics list --format json
 
 
 ```
-(protoPayload.serviceName="cloudresourcemanager.googleapis.com") 
-AND (ProjectOwnership OR projectOwnerInvitee) 
-OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="REMOVE" 
-AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner") 
-OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="ADD" 
+(protoPayload.serviceName="cloudresourcemanager.googleapis.com")
+AND (ProjectOwnership OR projectOwnerInvitee)
+OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="REMOVE"
+AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner")
+OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="ADD"
 AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner")
 
 ```
@@ -5982,9 +5982,9 @@ Evidence or test output indicates that log metric filter(s) and alert(s) exist f
 
 
 ```
-resource.type="iam_role" 
-AND (protoPayload.methodName="google.iam.admin.v1.CreateRole" 
-OR protoPayload.methodName="google.iam.admin.v1.DeleteRole" 
+resource.type="iam_role"
+AND (protoPayload.methodName="google.iam.admin.v1.CreateRole"
+OR protoPayload.methodName="google.iam.admin.v1.DeleteRole"
 OR protoPayload.methodName="google.iam.admin.v1.UpdateRole")
 ```
 
@@ -6444,7 +6444,7 @@ Evidence or test output indicates that an activity log alert exists for Delete P
 
 ---
 
-### 3.11.7 Ensure that Activity Log Alert exists for Create or Update Network Security Group 
+### 3.11.7 Ensure that Activity Log Alert exists for Create or Update Network Security Group
 **Platform:** Azure
 
 **Rationale:** Monitoring for Create or Update Network Security Group events gives insight into network access changes and may reduce the time it takes to detect suspicious activity.
@@ -6648,7 +6648,7 @@ Evidence or test output indicates that an activity log alert exists for Delete S
 
 ---
 
-### 3.11.11 Ensure that Activity Log Alert exists for Create or Update SQL Server Firewall Rule 
+### 3.11.11 Ensure that Activity Log Alert exists for Create or Update SQL Server Firewall Rule
 **Platform:** Azure
 
 **Rationale:** Monitoring for Create or Update SQL Server Firewall Rule events gives insight into network access changes and may reduce the time it takes to detect suspicious activity.
@@ -7022,7 +7022,7 @@ For each Google Cloud Platform project,
 
 
 ```
-gcloud config set project <Project-ID> 
+gcloud config set project <Project-ID>
 
 ```
 
@@ -7032,7 +7032,7 @@ gcloud config set project <Project-ID>
 
 
 ```
-gcloud compute networks list 
+gcloud compute networks list
 ```
 
 
@@ -7942,9 +7942,9 @@ Output if Block Public access is enabled:
 ```
 {
  "PublicAccessBlockConfiguration": {
- "IgnorePublicAcls": true, 
- "BlockPublicPolicy": true, 
- "BlockPublicAcls": true, 
+ "IgnorePublicAcls": true,
+ "BlockPublicPolicy": true,
+ "BlockPublicAcls": true,
  "RestrictPublicBuckets": true
  }
 }
@@ -8825,7 +8825,7 @@ Evidence or test output indicates that no RDS instance allows Public Accessibili
 
 ---
 
-### 6.5.2 Ensure no Azure SQL Databases allow ingress from 0.0.0.0/0 (ANY IP) 
+### 6.5.2 Ensure no Azure SQL Databases allow ingress from 0.0.0.0/0 (ANY IP)
 **Platform:** Azure
 
 **Rationale:** Azure SQL Server includes a firewall to block access to unauthorized connections. More granular IP addresses can be defined by referencing the range of addresses available from specific data centers.
@@ -9729,7 +9729,7 @@ Once configured, logs may generate large volumes of data. Organizations must ens
 
 ---
 
-### 6.14.1 Ensure Server Parameter 'log_retention_days' is greater than 3 days for PostgreSQL Database Server 
+### 6.14.1 Ensure Server Parameter 'log_retention_days' is greater than 3 days for PostgreSQL Database Server
 **Platform:** Azure
 
 **Rationale:** Configuring `log_retention_days` determines the duration in days that `Azure Database for PostgreSQL` retains log files. Query and error logs can be used to identify, troubleshoot, and repair configuration errors and sub-optimal performance.
@@ -10054,7 +10054,7 @@ Run the command by providing `<INSTANCE_NAME>`. Ensure the value of the flag is 
 
 
 ```
-gcloud sql instances describe <INSTANCE_NAME> --format="json" | jq '.settings|.|.databaseFlags[]|select(.name=="cloudsql.enable_pgaudit")|.value' 
+gcloud sql instances describe <INSTANCE_NAME> --format="json" | jq '.settings|.|.databaseFlags[]|select(.name=="cloudsql.enable_pgaudit")|.value'
 ```
 
 
@@ -10068,7 +10068,7 @@ gcloud sql instances describe <INSTANCE_NAME> --format="json" | jq '.settings|.|
 
 
 ```
-SELECT * 
+SELECT *
 FROM pg_extension;
 
 ```
@@ -10117,7 +10117,7 @@ Evidence or test output indicates that all Cloud SQL PostgreSQL instance(s) have
 ### 6.15.8 Database logging should be enabled
 **Platform:** AWS
 
-**Rationale:** RDS databases should have relevant logs enabled. Database logging provides detailed records of requests made to RDS. Database logs can assist with security and access audits and can help to diagnose availability issues. 
+**Rationale:** RDS databases should have relevant logs enabled. Database logging provides detailed records of requests made to RDS. Database logs can assist with security and access audits and can help to diagnose availability issues.
 
 **External Reference:** [AWS Security Hub - RDS.9](https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-9)
 


### PR DESCRIPTION
Made the fix suggested in the linked issue.

Also this commit contains changes to drop trailing spaces on a bunch of lines. This is not strictly required but it seems like a sensible change too.