### PR TITLE
Bumping document version numbers to 1.0

### DIFF
--- a/Cloud App and Config Profile/Cloud App and Config Specification.md
+++ b/Cloud App and Config Profile/Cloud App and Config Specification.md
@@ -1,13 +1,14 @@
 # App Defense Alliance Cloud Profile
 ## Specification
-Version 0.9 - Aug 5, 2024
+Version 1.0 - 10-OCT 24
 
 # Revision History
 | Version | Date  | Description|
 |----|----|-----------------|
-| 0.5 | 5/8/24 | Initial draft based on Web App Tiger Team review of CIS Cloud Foundations Benchmarks |
-| 0.7 | 5/25/24 | Updates from Tiger Team review of 0.5 spec |
-| 0.9 | 8/9/24 | Updates from ASA WG leads review of 0.7 spec |
+| 0.5 | 8-MAY 24 | Initial draft based on Web App Tiger Team review of CIS Cloud Foundations Benchmarks |
+| 0.7 | 25-MAY 24 | Updates from Tiger Team review of 0.5 spec |
+| 0.9 | 9-AUG 24 | Updates from ASA WG leads review of 0.7 spec |
+| 1.0 | 10-OCT 24 | Approved for release by the alliance steering committee |
 
 
 # Contributors

--- a/Cloud App and Config Profile/Cloud App and Config Test Guide.md
+++ b/Cloud App and Config Profile/Cloud App and Config Test Guide.md
@@ -1,6 +1,6 @@
 # Cloud Config and App Profile - Test Plan
 
-Version 0.9 - August 5, 2024
+Version 1.0 - 10-OCT 24
 
 
 

--- a/Cloud App and Config Profile/Cloud Profile and Config Audit Summary.md
+++ b/Cloud App and Config Profile/Cloud Profile and Config Audit Summary.md
@@ -1,7 +1,7 @@
 # App Defense Alliance Cloud App and Config Audit Summary
 ## Audit Requirements Per Platform
 
-Version 0.9 - August 5, 2024
+Version 1.0 - 10-OCT 24
 
 
 

--- a/Mobile App Profile/Mobile App Specification.md
+++ b/Mobile App Profile/Mobile App Specification.md
@@ -1,15 +1,16 @@
 
 # App Defense Alliance Mobile Application Specification
 
-Version 0.9 - August 5, 2024
+Version 1.0 - 10-OCT 24
 
 ## Revision History
 
 | Version | Date | Description |
 | --- | :--- | :--- |
-| 0.5 | 5/10/24 | Initial draft based on Mobile App Tiger Team review of MASVS specification |
-| 0.7 | 5/25/24 | Updates from Tiger Team review of 0.5 spec |
-| 0.9 | 8/9/24 | Updates from ASA WG leads review of 0.7 spec |
+| 0.5 | 10-MAY 24 | Initial draft based on Mobile App Tiger Team review of MASVS specification |
+| 0.7 | 25-MAY 24 | Updates from Tiger Team review of 0.5 spec |
+| 0.9 | 9-AUG 24 | Updates from ASA WG leads review of 0.7 spec |
+| 1.0 | 10-OCT 24 | Approved for release by the alliance steering committee |
 
 ## Acknowledgements
 

--- a/Mobile App Profile/Mobile App Test Guide.md
+++ b/Mobile App Profile/Mobile App Test Guide.md
@@ -1,6 +1,6 @@
 # App Defense Alliance Mobile Application Specification
 
-Version 0.9 - August 5, 2024
+Version 1.0 - 10-OCT 24
 
 ## Revision History
 
@@ -9,6 +9,7 @@ Version 0.9 - August 5, 2024
 | 0.5 | 5/10/24 | Initial draft based on Mobile App Tiger Team review of MASVS specification |
 | 0.7 | 5/25/24 | Updates from Tiger Team review of 0.5 spec |
 | 0.9 | 8/9/24 | Updates from ASA WG leads review of 0.7 spec |
+| 1.0 | 10-OCT 24 | Approved for release by the alliance steering committee |
 
 ## Contributors
 The App Defense Alliance Application Security Assessment Working Group (ASA WG) would like to thank the following individuals for their contributions to this specification:

--- a/Web App Profile/Web App Specification.md
+++ b/Web App Profile/Web App Specification.md
@@ -1,5 +1,5 @@
 # App Defense Alliance Web Application Specification
-Version 0.9 - August 5, 2024
+Version 1.0 - 10-OCT 24
 
 
 # Revision History
@@ -8,6 +8,7 @@ Version 0.9 - August 5, 2024
 | 0.5 | 5/25/24 | Initial draft based on Web App Tiger Team review of ASVS specification |
 | 0.7 | 5/25/24 | Updates from Tiger Team review of 0.5 spec |
 | 0.9 | 8/9/24 | Updates from ASA WG leads review of 0.7 spec |
+| 1.0 | 10-OCT 24 | Approved for release by the alliance steering committee |
 
 # Contributors
 The App Defense Alliance Application Security Assessment Working Group (ASA WG) would like to thank the following individuals for their contributions to this specification.

--- a/Web App Profile/Web App Test Guide.md
+++ b/Web App Profile/Web App Test Guide.md
@@ -1,13 +1,14 @@
 # App Defense Alliance Web Application Testing Guide
-Version 0.9 - August 5, 2024
+Version 1.0 - 10-OCT 24
 
 
 # Revision History
 | Version | Date  | Description|
 |----|----|-----------------|
-| 0.5 | 5/25/24 | Initial draft based on Web App Tiger Team review of ASVS specification |
-| 0.7 | 5/25/24 | Updates from Tiger Team review of 0.5 spec |
-| 0.9 | 8/9/24 | Updates from ASA WG leads review of 0.7 spec |
+| 0.5 | 25-MAY 24 | Initial draft based on Web App Tiger Team review of ASVS specification |
+| 0.7 | 25-MAY 24 | Updates from Tiger Team review of 0.5 spec |
+| 0.9 | 9-AUG 24 | Updates from ASA WG leads review of 0.7 spec |
+| 1.0 | 10-OCT 24 | Approved for release by the alliance steering committee |
 
 
 # Table of Contents


### PR DESCRIPTION
The alliance steering committee has officially reviewed and approved the current versions of the mobile, web, and cloud standards for release. This commit therefore bumps the logical version number within the docs up to v1.0.