### PR TITLE
Fix incorrect test reference for cryptographic key management in 1.2.2.2

### DIFF
--- a/Mobile App Profile/Mobile App Test Guide.md
+++ b/Mobile App Profile/Mobile App Test Guide.md
@@ -421,7 +421,7 @@ _AL1_
 
 _AL2_
 
-1. Follow the testing procedures outlined in [MASTG-TEST-0062](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/ios/MASVS-CRYPTO/MASTG-TEST-0062.md)
+1. Follow the testing procedures outlined in [MASTG-TEST-0015](https://github.com/OWASP/owasp-mastg/blob/v1.7.0/tests/android/MASVS-CRYPTO/MASTG-TEST-0015.md)
 
 ##### Verification
 


### PR DESCRIPTION
The current reference to MASTG-TEST-0062 in 1.2.2.2 (Cryptographic key management shall be implemented properly) is incorrect for Android. MASTG-TEST-0062 is an iOS-specific test, while the correct test for Android is MASTG-TEST-0015.