### PR TITLE
Fix inaccurate copy/paste

### DIFF
--- a/Mobile App Profile/Mobile App Test Guide.md
+++ b/Mobile App Profile/Mobile App Test Guide.md
@@ -1,4 +1,4 @@
-# App Defense Alliance Mobile Application Specification
+# App Defense Alliance Mobile Application Testing Guide
 
 Version 1.0 - 10-OCT 24
 


### PR DESCRIPTION
Update to remove copy/paste from App Specification to instead say "Application Testing Guide"