### PR TITLE
Add Multi-AZ deployments check for RDS (CIS v7 3.2.4)

### DIFF
--- a/Cloud App and Config Profile/Cloud App and Config Specification.md
+++ b/Cloud App and Config Profile/Cloud App and Config Specification.md
@@ -1295,6 +1295,7 @@ Industry-recommended hardening configuration templates reduce the attack surface
 | Spec | Platform | Description |
 |---|-----|----------|
 | 6.1.1 | Google | Ensure That the ‘Local_infile’ Database Flag for a Cloud SQL MySQL Instance Is Set to ‘Off’ |
+| 6.1.2 | AWS | Ensure Multi-AZ deployments are used for enhanced availability in Amazon RDS |
 
 ---
 

--- a/Cloud App and Config Profile/Cloud App and Config Test Guide.md
+++ b/Cloud App and Config Profile/Cloud App and Config Test Guide.md
@@ -383,6 +383,8 @@ Version 1.0 - 10-OCT 24
 
 [6.1.1 Ensure That the ‘Local_infile’ Database Flag for a Cloud SQL MySQL Instance Is Set to ‘Off’](#611-ensure-that-the-local_infile-database-flag-for-a-cloud-sql-mysql-instance-is-set-to-off)
 
+[6.1.2 Ensure Multi-AZ deployments are used for enhanced availability in Amazon RDS](#612-ensure-multi-az-deployments-are-used-for-enhanced-availability-in-amazon-rds)
+
 [6.2 Allowlist Authorized Scripts](#62-allowlist-authorized-scripts)
 
 [6.2.1 Ensure 'external scripts enabled' database flag for Cloud SQL SQL Server instance is set to 'off'](#621-ensure-external-scripts-enabled-database-flag-for-cloud-sql-sql-server-instance-is-set-to-off)
@@ -8358,6 +8360,39 @@ gcloud sql instances describe INSTANCE_NAME --format=json | jq '.settings.databa
 **Verification**
 
 Evidence or test output indicates that Cloud SQL MySQL instance(s) have the Local_infile database flag set to off.
+
+
+---
+
+### 6.1.2 Ensure Multi-AZ deployments are used for enhanced availability in Amazon RDS
+**Platform:** AWS
+
+**Rationale:** Database availability is crucial for maintaining service uptime, particularly for applications critical to the business. Multi-AZ deployments provide enhanced availability and durability using synchronous replication to a standby instance in a different Availability Zone, with automatic failover in the event of infrastructure failure.
+
+**External Reference:** CIS Amazon Web Services Foundations Benchmark v7.0.0, Section 3.2.4
+
+**Evidence**
+
+**From Console:**
+
+1. Login to the AWS Management Console and open the RDS dashboard at `https://console.aws.amazon.com/rds/`
+2. In the navigation pane, select `Databases`
+3. Select each RDS instance and navigate to the `Configuration` tab
+4. Under the `Availability` section, check the `Multi-AZ` status — it should display `Yes`
+
+**From Command Line:**
+
+1. Run the following command to list all RDS instances and their Multi-AZ status:
+
+```
+aws rds describe-db-instances --query 'DBInstances[*].[DBInstanceIdentifier,MultiAZ,Engine]' --output table
+```
+
+2. Verify that `MultiAZ` is `true` for all production database instances.
+
+**Verification**
+
+Evidence or test output indicates that Multi-AZ deployments are enabled for RDS instances. Note that the decision of which databases require Multi-AZ is context-dependent; development/test databases may not require Multi-AZ.
 
 
 ---

--- a/cloud-assessment/ada_cloud_audit/checks/aws/database.py
+++ b/cloud-assessment/ada_cloud_audit/checks/aws/database.py
@@ -1,10 +1,11 @@
 """AWS Database checks for ADA Cloud assessment.
 
-Covers 4 requirements:
+Covers 5 requirements:
 - 6.4.1: RDS encryption-at-rest enabled
 - 6.5.1: RDS not publicly accessible
 - 6.12.1: RDS auto minor version upgrade enabled
 - 6.15.8: Database logging enabled
+- 6.1.2: RDS Multi-AZ deployments
 """
 
 from __future__ import annotations
@@ -164,6 +165,46 @@ def check_rds_logging_enabled(session: boto3.Session) -> "RequirementResult":
         session,
         "6.15.8",
         "Database logging should be enabled",
+        "AWS",
+        _check_region,
+    )
+
+
+def check_rds_multi_az(session: boto3.Session) -> "RequirementResult":
+    """ADA 6.1.2: Ensure Multi-AZ deployments are used for enhanced availability in Amazon RDS."""
+
+    def _check_region(session: boto3.Session, region: str) -> tuple[bool, str, dict]:
+        rds = session.client("rds", region_name=region)
+        try:
+            paginator = rds.get_paginator("describe_db_instances")
+            non_multi_az = []
+            total = 0
+            for page in paginator.paginate():
+                for db in page["DBInstances"]:
+                    total += 1
+                    if not db.get("MultiAZ", False):
+                        non_multi_az.append(
+                            f"{db['DBInstanceIdentifier']} (Engine: {db.get('Engine', 'unknown')})"
+                        )
+        except ClientError as e:
+            if e.response["Error"]["Code"] in ("AuthFailure", "OptInRequired"):
+                return True, "Region not accessible", {}
+            raise
+
+        if total == 0:
+            return True, "No RDS instances found", {}
+        if non_multi_az:
+            return (
+                False,
+                f"RDS instances without Multi-AZ: {', '.join(non_multi_az)}",
+                {"non_multi_az": non_multi_az, "total": total},
+            )
+        return True, f"All {total} RDS instances have Multi-AZ enabled", {"total": total}
+
+    return run_multi_region(
+        session,
+        "6.1.2",
+        "Ensure Multi-AZ deployments are used for enhanced availability in Amazon RDS",
         "AWS",
         _check_region,
     )

--- a/cloud-assessment/ada_cloud_audit/checks/registry.py
+++ b/cloud-assessment/ada_cloud_audit/checks/registry.py
@@ -80,6 +80,7 @@ def _register_aws_checks() -> None:
         "6.5.1": database.check_rds_public_access,
         "6.12.1": database.check_rds_auto_minor_upgrade,
         "6.15.8": database.check_rds_logging_enabled,
+        "6.1.2": database.check_rds_multi_az,
     }
 
 


### PR DESCRIPTION
## 🔗 Linked Issue
Fixes #253

## 📖 Summary of Changes
- Added new check **6.1.2**: Ensure Multi-AZ deployments are used for enhanced availability in Amazon RDS
- CIS v7 reference: Section 3.2.4 (Level 1, Manual)
- Added `check_rds_multi_az()` in `database.py` using existing `run_multi_region` pattern

## 📋 Requirement Verification
- [ ] The proposed requirement text matches the approved Issue.
- [ ] All automated tests/checks pass on the `develop` branch.

## ⚖️ Governance & Consensus
- [ ] **Consensus Reached:** The Working Group has reached a rough consensus on this change.
- [ ] **Voting:** If required, the formal vote has passed (Link to vote results: [URL]).
- [ ] **Reviewers:** At least two members of the Working Group have signed off on this PR.

## 📸 Additional Context
Part of the CIS AWS Foundations Benchmark v2 → v7 update effort.