### PR TITLE
Add CIFS access restriction check (CIS v7 6.1.2)

### DIFF
--- a/Cloud App and Config Profile/Cloud App and Config Specification.md
+++ b/Cloud App and Config Profile/Cloud App and Config Specification.md
@@ -1105,6 +1105,7 @@ Firewalls help to prevent unauthorized users from accessing servers or sending m
 | 4.3.5 | AWS | Ensure no Network ACLs allow ingress from 0.0.0.0/0 to remote server administration ports |
 | 4.3.6 | AWS | Ensure no security groups allow ingress from 0.0.0.0/0 to remote server administration ports |
 | 4.3.7 | AWS | Ensure no security groups allow ingress from ::/0 to remote server administration ports |
+| 4.3.8 | AWS | Ensure CIFS access is restricted to trusted networks to prevent unauthorized access |
 
 
 ---

--- a/Cloud App and Config Profile/Cloud App and Config Test Guide.md
+++ b/Cloud App and Config Profile/Cloud App and Config Test Guide.md
@@ -334,6 +334,8 @@ Version 1.0 - 10-OCT 24
 
 [4.3.7 Ensure no security groups allow ingress from ::/0 to remote server administration ports](#437-ensure-no-security-groups-allow-ingress-from-0-to-remote-server-administration-ports)
 
+[4.3.8 Ensure CIFS access is restricted to trusted networks to prevent unauthorized access](#438-ensure-cifs-access-is-restricted-to-trusted-networks-to-prevent-unauthorized-access)
+
 
 [5 Storage](#5-storage)
 
@@ -7513,6 +7515,45 @@ Perform the following to determine if the account is configured as prescribed:
 **Verification**
 
 Evidence or test output indicates that no security group allows ingress to port 22 or port 3389 from ::/0
+
+
+---
+
+### 4.3.8 Ensure CIFS access is restricted to trusted networks to prevent unauthorized access
+**Platform:** AWS
+
+**Rationale:** Common Internet File System (CIFS) is a network file-sharing protocol. Unrestricted CIFS access on port 445 can expose file shares to unauthorized users, leading to data breaches. Security groups should not allow ingress from 0.0.0.0/0 or ::/0 on port 445.
+
+**External Reference:** CIS Amazon Web Services Foundations Benchmark v7.0.0, Section 6.1.2
+
+**Evidence**
+
+**From Console:**
+
+1. Login to the AWS Management Console
+2. Navigate to the EC2 Dashboard and select `Security Groups` under `Network & Security`
+3. For each security group, review the inbound rules
+4. Check for rules that allow access from `0.0.0.0/0` or `::/0` on port 445
+
+**From Command Line:**
+
+1. List all security groups:
+
+```
+aws ec2 describe-security-groups --region <region>
+```
+
+2. Check for unrestricted CIFS access on port 445:
+
+```
+aws ec2 describe-security-groups --region <region> --group-ids <sg-id> --query "SecurityGroups[*].IpPermissions[?((IpProtocol=='-1') || (FromPort<=\`445\` && ToPort>=\`445\`))].{IpProtocol:IpProtocol,FromPort:FromPort,ToPort:ToPort,CIDRv4:IpRanges[*].CidrIp,CIDRv6:Ipv6Ranges[*].CidrIpv6}"
+```
+
+3. Look for `0.0.0.0/0` or `::/0` in the output. Repeat for all regions.
+
+**Verification**
+
+Evidence or test output indicates that no security group allows unrestricted CIFS access (port 445) from 0.0.0.0/0 or ::/0.
 
 
 ---

--- a/cloud-assessment/ada_cloud_audit/checks/aws/compute.py
+++ b/cloud-assessment/ada_cloud_audit/checks/aws/compute.py
@@ -6,6 +6,7 @@ Covers 4 requirements:
 - 4.3.5: WITHDRAWN (auto NA)
 - 4.3.6: No security groups allow 0.0.0.0/0 ingress to admin ports
 - 4.3.7: No security groups allow ::/0 ingress to admin ports
+- 4.3.8: CIFS access restricted to trusted networks
 """
 
 from __future__ import annotations
@@ -216,4 +217,92 @@ def check_sg_ipv6_admin_ports(session: boto3.Session) -> "RequirementResult":
         "::/0",
         "4.3.7",
         "Ensure no security groups allow ingress from ::/0 to remote server administration ports",
+    )
+
+
+# Port 445 (CIFS) restriction
+CIFS_PORTS = {445}
+
+
+def _check_security_groups_cifs(
+    session: boto3.Session, cidr_key: str, cidr_value: str, spec_id: str, title: str
+) -> "RequirementResult":
+    """Check security groups for unrestricted CIFS port 445 access."""
+
+    def _check_region(session: boto3.Session, region: str) -> tuple[bool, str, dict]:
+        ec2 = session.client("ec2", region_name=region)
+        try:
+            paginator = ec2.get_paginator("describe_security_groups")
+            non_compliant = []
+            for page in paginator.paginate():
+                for sg in page["SecurityGroups"]:
+                    sg_id = sg["GroupId"]
+                    sg_name = sg.get("GroupName", "")
+                    for rule in sg.get("IpPermissions", []):
+                        ip_protocol = rule.get("IpProtocol", "")
+                        from_port = rule.get("FromPort", 0)
+                        to_port = rule.get("ToPort", 65535)
+
+                        if ip_protocol == "-1":
+                            from_port = 0
+                            to_port = 65535
+
+                        if ip_protocol not in ("-1", "tcp", "udp", "6", "17"):
+                            continue
+
+                        cifs_exposed = any(
+                            _port_in_range(from_port, to_port, p) for p in CIFS_PORTS
+                        )
+                        if not cifs_exposed:
+                            continue
+
+                        ranges = (
+                            rule.get("IpRanges", [])
+                            if cidr_key == "CidrIp"
+                            else rule.get("Ipv6Ranges", [])
+                        )
+                        for ip_range in ranges:
+                            if ip_range.get(cidr_key) == cidr_value:
+                                non_compliant.append(
+                                    f"{sg_id} ({sg_name}): port 445 open to {cidr_value}"
+                                )
+        except ClientError as e:
+            if e.response["Error"]["Code"] in ("AuthFailure", "OptInRequired"):
+                return True, "Region not accessible", {}
+            raise
+
+        if non_compliant:
+            return (
+                False,
+                f"Security groups with unrestricted CIFS access: {'; '.join(non_compliant)}",
+                {"non_compliant": non_compliant},
+            )
+        return True, f"No security groups allow {cidr_value} ingress to port 445", {}
+
+    return run_multi_region(session, spec_id, title, "AWS", _check_region)
+
+
+def check_cifs_restricted(session: boto3.Session) -> "RequirementResult":
+    """ADA 4.3.8: Ensure CIFS access is restricted to trusted networks."""
+    # Check both IPv4 and IPv6
+    result_v4 = _check_security_groups_cifs(
+        session, "CidrIp", "0.0.0.0/0", "4.3.8",
+        "Ensure CIFS access is restricted to trusted networks to prevent unauthorized access",
+    )
+    if result_v4.verdict == Verdict.FAIL:
+        return result_v4
+
+    result_v6 = _check_security_groups_cifs(
+        session, "CidrIpv6", "::/0", "4.3.8",
+        "Ensure CIFS access is restricted to trusted networks to prevent unauthorized access",
+    )
+    if result_v6.verdict == Verdict.FAIL:
+        return result_v6
+
+    return make_result(
+        "4.3.8",
+        "Ensure CIFS access is restricted to trusted networks to prevent unauthorized access",
+        "AWS",
+        Verdict.PASS,
+        "No security groups allow unrestricted CIFS access (port 445) from 0.0.0.0/0 or ::/0",
     )

--- a/cloud-assessment/ada_cloud_audit/checks/registry.py
+++ b/cloud-assessment/ada_cloud_audit/checks/registry.py
@@ -69,6 +69,7 @@ def _register_aws_checks() -> None:
         "4.3.5": compute.check_nacl_admin_ports_withdrawn,
         "4.3.6": compute.check_sg_ipv4_admin_ports,
         "4.3.7": compute.check_sg_ipv6_admin_ports,
+        "4.3.8": compute.check_cifs_restricted,
 
         # Data Protection - Storage
         "5.4.1": storage.check_ebs_encryption,


### PR DESCRIPTION
## 🔗 Linked Issue
Fixes #255

## 📖 Summary of Changes
- Added new check **4.3.8**: Ensure CIFS access is restricted to trusted networks to prevent unauthorized access
- CIS v7 reference: Section 6.1.2 (Level 1, Automated)
- Checks security groups for unrestricted port 445 access from 0.0.0.0/0 and ::/0
- Added `check_cifs_restricted()` in `compute.py` following the existing SG check pattern

## 📋 Requirement Verification
- [ ] The proposed requirement text matches the approved Issue.
- [ ] All automated tests/checks pass on the `develop` branch.

## ⚖️ Governance & Consensus
- [ ] **Consensus Reached:** The Working Group has reached a rough consensus on this change.
- [ ] **Voting:** If required, the formal vote has passed (Link to vote results: [URL]).
- [ ] **Reviewers:** At least two members of the Working Group have signed off on this PR.

## 📸 Additional Context
Part of the CIS AWS Foundations Benchmark v2 → v7 update effort.