### PR TITLE
Remove GCP SSH/RDP firewall checks reclassified to L2 in CIS v4

### DIFF
--- a/Cloud App and Config Profile/Cloud App and Config Specification.md
+++ b/Cloud App and Config Profile/Cloud App and Config Specification.md
@@ -1100,8 +1100,8 @@ Firewalls help to prevent unauthorized users from accessing servers or sending m
 |---|-----|----------|
 | 4.3.1 | Azure | Ensure that RDP access from the Internet is evaluated and restricted |
 | 4.3.2 | Azure | Ensure that SSH access from the Internet is evaluated and restricted |
-| 4.3.3 | Google | Ensure That SSH Access Is Restricted From the Internet |
-| 4.3.4 | Google | Ensure That RDP Access Is Restricted From the Internet |
+| 4.3.3 | Google | REMOVED — Reclassified to Level 2 in CIS v4.0.0 |
+| 4.3.4 | Google | REMOVED — Reclassified to Level 2 in CIS v4.0.0 |
 | 4.3.5 | AWS | Ensure no Network ACLs allow ingress from 0.0.0.0/0 to remote server administration ports |
 | 4.3.6 | AWS | Ensure no security groups allow ingress from 0.0.0.0/0 to remote server administration ports |
 | 4.3.7 | AWS | Ensure no security groups allow ingress from ::/0 to remote server administration ports |

--- a/Cloud App and Config Profile/Cloud App and Config Test Guide.md
+++ b/Cloud App and Config Profile/Cloud App and Config Test Guide.md
@@ -7360,87 +7360,15 @@ Evidence or test output indicates that no network security group is configured t
 
 ---
 
-### 4.3.3 Ensure That SSH Access Is Restricted From the Internet
-**Platform:** Google
+### 4.3.3 REMOVED — Reclassified to Level 2 in CIS v4.0.0
 
-**Rationale:** GCP `Firewall Rules` within a `VPC Network` apply to outgoing (egress) traffic from instances and incoming (ingress) traffic to instances in the network. Egress and ingress traffic flows are controlled even if the traffic stays within the network (for example, instance-to-instance communication). For an instance to have outgoing Internet access, the network must have a valid Internet gateway route or custom route whose destination IP is specified. This route simply defines the path to the Internet, to avoid the most general `(0.0.0.0/0)` destination `IP Range` specified from the Internet through `SSH` with the default `Port 22`. Generic access from the Internet to a specific IP Range needs to be restricted.
-
-**External Reference:** CIS Google Cloud Platform Foundation Benchmark v2.0.0, Section 3.6
-
-**Evidence**
-
-**From Google Cloud Console**
-
-
-
-1. Go to `VPC network`.
-2. Go to the `Firewall Rules`.
-3. Ensure that `Port` is not equal to `22` and `Action` is not set to `Allow`.
-4. Ensure `IP Ranges` is not equal to `0.0.0.0/0` under `Source filters`.
-
-**From Google Cloud CLI**
-
-gcloud compute firewall-rules list --format=table'(name,direction,sourceRanges,allowed)'
-
-Ensure that there is no rule matching the below criteria:
-   * `SOURCE_RANGES` is `0.0.0.0/0`
-   * AND `DIRECTION` is `INGRESS`
-   * AND IPProtocol is `tcp` or `ALL`
-   * AND `PORTS` is set to `22` or `range containing 22` or `Null (not set)`
-
-Note:
-
-
-
-   * When ALL TCP ports are allowed in a rule, PORT does not have any value set (`NULL`)
-   * When ALL Protocols are allowed in a rule, PORT does not have any value set (`NULL`)
-
-**Verification**
-
-Evidence or test output indicates that no firewall rule allows inbound connections to port 22 from the unrestricted public internet.
-
+**Status:** Removed — This requirement (Ensure That SSH Access Is Restricted From the Internet) was reclassified from Level 1 to Level 2 in CIS Google Cloud Platform Foundation Benchmark v4.0.0 (Section 3.6).
 
 ---
 
-### 4.3.4 Ensure That RDP Access Is Restricted From the Internet
-**Platform:** Google
+### 4.3.4 REMOVED — Reclassified to Level 2 in CIS v4.0.0
 
-**Rationale:** GCP `Firewall Rules` within a `VPC Network`. These rules apply to outgoing (egress) traffic from instances and incoming (ingress) traffic to instances in the network. Egress and ingress traffic flows are controlled even if the traffic stays within the network (for example, instance-to-instance communication). For an instance to have outgoing Internet access, the network must have a valid Internet gateway route or custom route whose destination IP is specified. This route simply defines the path to the Internet, to avoid the most general `(0.0.0.0/0)` destination `IP Range` specified from the Internet through `RDP` with the default `Port 3389`. Generic access from the Internet to a specific IP Range should be restricted.
-
-**External Reference:** CIS Google Cloud Platform Foundation Benchmark v2.0.0, Section 3.7
-
-**Evidence**
-
-**From Google Cloud Console**
-
-
-
-1. Go to `VPC network`.
-2. Go to the `Firewall Rules`.
-3. Ensure `Port` is not equal to `3389` and `Action` is not `Allow`.
-4. Ensure `IP Ranges` is not equal to `0.0.0.0/0` under `Source filters`.
-
-**From Google Cloud CLI**
-
-gcloud compute firewall-rules list --format=table'(name,direction,sourceRanges,allowed.ports)'
-
-Ensure that there is no rule matching the below criteria:
-   * `SOURCE_RANGES` is `0.0.0.0/0`
-   * AND `DIRECTION` is `INGRESS`
-   * AND IPProtocol is `TCP` or `ALL`
-   * AND `PORTS` is set to `3389` or `range containing 3389` or `Null (not set)`
-
-Note:
-
-
-
-   * When ALL TCP ports are allowed in a rule, PORT does not have any value set (`NULL`)
-   * When ALL Protocols are allowed in a rule, PORT does not have any value set (`NULL`)
-
-**Verification**
-
-Evidence or test output indicates that no firewall rule allows inbound connections to port 3389 from the unrestricted public internet.
-
+**Status:** Removed — This requirement (Ensure That RDP Access Is Restricted From the Internet) was reclassified from Level 1 to Level 2 in CIS Google Cloud Platform Foundation Benchmark v4.0.0 (Section 3.7).
 
 ---
 

--- a/cloud-assessment/ada_cloud_audit/checks/gcp/networking.py
+++ b/cloud-assessment/ada_cloud_audit/checks/gcp/networking.py
@@ -1,13 +1,11 @@
 """GCP Networking checks for ADA Cloud assessment.
 
-Covers 7 requirements:
+Covers 5 requirements:
 - 4.1.1: No HTTPS/SSL proxy LBs with weak cipher suites
 - 4.2.1: No legacy networks exist
 - 4.2.2: DNSSEC enabled for Cloud DNS
 - 4.2.3: RSASHA1 not used for key-signing key in DNSSEC
 - 4.2.4: RSASHA1 not used for zone-signing key in DNSSEC
-- 4.3.3: SSH access restricted from internet (firewall rules)
-- 4.3.4: RDP access restricted from internet (firewall rules)
 """
 
 from __future__ import annotations
@@ -220,76 +218,3 @@ def check_dnssec_zone_signing(session: GCPSession) -> RequirementResult:
     )
 
 
-def _check_firewall_port(session: GCPSession, spec_id: str, title: str,
-                         port: int, port_name: str) -> RequirementResult:
-    """Common helper for firewall port checks (SSH/RDP)."""
-    try:
-        from google.cloud import compute_v1
-
-        client = compute_v1.FirewallsClient(credentials=session.credentials)
-        firewalls = list(client.list(project=session.project_id))
-
-        non_compliant = []
-        for fw in firewalls:
-            # Only check ingress rules
-            if fw.direction != "INGRESS":
-                continue
-
-            # Check if the rule allows the target port
-            port_allowed = False
-            for allowed in fw.allowed:
-                if allowed.I_p_protocol in ("all", "tcp"):
-                    if not allowed.ports:
-                        # No port restriction = all ports
-                        port_allowed = True
-                    else:
-                        for p in allowed.ports:
-                            if "-" in p:
-                                start, end = p.split("-")
-                                if int(start) <= port <= int(end):
-                                    port_allowed = True
-                            elif int(p) == port:
-                                port_allowed = True
-
-            if not port_allowed:
-                continue
-
-            # Check if source ranges include 0.0.0.0/0
-            source_ranges = list(fw.source_ranges) if fw.source_ranges else []
-            if "0.0.0.0/0" in source_ranges:
-                non_compliant.append(
-                    f"{fw.name} (allows {port_name} port {port} from 0.0.0.0/0)"
-                )
-
-        if non_compliant:
-            return make_result(spec_id, title, "GCP", Verdict.FAIL,
-                             f"Firewall rules allowing {port_name} from internet:\n"
-                             + "\n".join(non_compliant),
-                             {"non_compliant": non_compliant})
-        return make_result(spec_id, title, "GCP", Verdict.PASS,
-                         f"No firewall rules allow unrestricted {port_name} access from the internet")
-    except Exception as e:
-        return make_result(spec_id, title, "GCP", Verdict.INCONCLUSIVE,
-                         f"Error checking firewall rules: {e}")
-
-
-def check_ssh_firewall(session: GCPSession) -> RequirementResult:
-    """ADA 4.3.3: Ensure SSH access is restricted from the internet."""
-    return _check_firewall_port(
-        session,
-        "4.3.3",
-        "Ensure that SSH access is restricted from the internet",
-        22,
-        "SSH",
-    )
-
-
-def check_rdp_firewall(session: GCPSession) -> RequirementResult:
-    """ADA 4.3.4: Ensure RDP access is restricted from the internet."""
-    return _check_firewall_port(
-        session,
-        "4.3.4",
-        "Ensure that RDP access is restricted from the internet",
-        3389,
-        "RDP",
-    )

--- a/cloud-assessment/ada_cloud_audit/checks/registry.py
+++ b/cloud-assessment/ada_cloud_audit/checks/registry.py
@@ -133,8 +133,6 @@ def _register_gcp_checks() -> None:
         "4.2.2": gcp_networking.check_dnssec,
         "4.2.3": gcp_networking.check_dnssec_key_signing,
         "4.2.4": gcp_networking.check_dnssec_zone_signing,
-        "4.3.3": gcp_networking.check_ssh_firewall,
-        "4.3.4": gcp_networking.check_rdp_firewall,
 
         # Storage (1 check)
         "5.5.3": gcp_storage.check_bucket_public_access,

--- a/cloud-assessment/tests/test_checks/test_gcp/test_networking.py
+++ b/cloud-assessment/tests/test_checks/test_gcp/test_networking.py
@@ -10,8 +10,6 @@ from ada_cloud_audit.checks.gcp.networking import (
     check_dnssec,
     check_dnssec_key_signing,
     check_dnssec_zone_signing,
-    check_ssh_firewall,
-    check_rdp_firewall,
 )
 from ada_cloud_audit.models import Verdict
 
@@ -143,70 +141,3 @@ def test_check_dnssec_zone_signing_pass(mock_zones, gcp_session):
     assert result.verdict == Verdict.PASS
 
 
-def test_check_ssh_firewall_pass(gcp_session, mock_google_modules):
-    mock_compute = mock_google_modules["google.cloud.compute_v1"]
-    mock_client = MagicMock()
-    mock_compute.FirewallsClient.return_value = mock_client
-
-    mock_fw = MagicMock()
-    mock_fw.name = "allow-internal-ssh"
-    mock_fw.direction = "INGRESS"
-    mock_allowed = MagicMock()
-    mock_allowed.I_p_protocol = "tcp"
-    mock_allowed.ports = ["22"]
-    mock_fw.allowed = [mock_allowed]
-    mock_fw.source_ranges = ["10.0.0.0/8"]
-    mock_client.list.return_value = [mock_fw]
-
-    result = check_ssh_firewall(gcp_session)
-    assert result.spec_id == "4.3.3"
-    assert result.verdict == Verdict.PASS
-
-
-def test_check_ssh_firewall_fail(gcp_session, mock_google_modules):
-    mock_compute = mock_google_modules["google.cloud.compute_v1"]
-    mock_client = MagicMock()
-    mock_compute.FirewallsClient.return_value = mock_client
-
-    mock_fw = MagicMock()
-    mock_fw.name = "allow-all-ssh"
-    mock_fw.direction = "INGRESS"
-    mock_allowed = MagicMock()
-    mock_allowed.I_p_protocol = "tcp"
-    mock_allowed.ports = ["22"]
-    mock_fw.allowed = [mock_allowed]
-    mock_fw.source_ranges = ["0.0.0.0/0"]
-    mock_client.list.return_value = [mock_fw]
-
-    result = check_ssh_firewall(gcp_session)
-    assert result.verdict == Verdict.FAIL
-
-
-def test_check_rdp_firewall_pass(gcp_session, mock_google_modules):
-    mock_compute = mock_google_modules["google.cloud.compute_v1"]
-    mock_client = MagicMock()
-    mock_compute.FirewallsClient.return_value = mock_client
-    mock_client.list.return_value = []
-
-    result = check_rdp_firewall(gcp_session)
-    assert result.spec_id == "4.3.4"
-    assert result.verdict == Verdict.PASS
-
-
-def test_check_rdp_firewall_fail(gcp_session, mock_google_modules):
-    mock_compute = mock_google_modules["google.cloud.compute_v1"]
-    mock_client = MagicMock()
-    mock_compute.FirewallsClient.return_value = mock_client
-
-    mock_fw = MagicMock()
-    mock_fw.name = "allow-rdp"
-    mock_fw.direction = "INGRESS"
-    mock_allowed = MagicMock()
-    mock_allowed.I_p_protocol = "tcp"
-    mock_allowed.ports = ["3389"]
-    mock_fw.allowed = [mock_allowed]
-    mock_fw.source_ranges = ["0.0.0.0/0"]
-    mock_client.list.return_value = [mock_fw]
-
-    result = check_rdp_firewall(gcp_session)
-    assert result.verdict == Verdict.FAIL


### PR DESCRIPTION
## 🔗 Linked Issue
Fixes #269

## 📖 Summary of Changes
- Marked **4.3.3** (SSH) and **4.3.4** (RDP) as REMOVED in Specification and Test Guide
- CIS GCP v4.0.0 reclassified these from Level 1 to Level 2
- Removed `check_ssh_firewall`, `check_rdp_firewall`, `_check_firewall_port` from `networking.py`
- Removed registry entries and tests

## 📋 Requirement Verification
- [ ] The proposed requirement text matches the approved Issue.
- [ ] All automated tests/checks pass on the `develop` branch.

## ⚖️ Governance & Consensus
- [ ] **Consensus Reached:** The Working Group has reached a rough consensus on this change.
- [ ] **Voting:** If required, the formal vote has passed (Link to vote results: [URL]).
- [ ] **Reviewers:** At least two members of the Working Group have signed off on this PR.

## 📸 Additional Context
Part of the CIS GCP Foundation Benchmark v2 → v4 update effort.