### PR TITLE
Add GCP-managed SA keys check (CIS v4 1.4)

### DIFF
--- a/Cloud App and Config Profile/Cloud App and Config Specification.md
+++ b/Cloud App and Config Profile/Cloud App and Config Specification.md
@@ -571,6 +571,7 @@ Establish and maintain a secure configuration process for enterprise assets (end
 | 2.8.2 | AWS | Ensure IAM password policy requires minimum length of 14 or greater |
 | 2.8.3 | AWS | Ensure there is only one active access key available for any single IAM user |
 | 2.8.4 | AWS | Ensure access keys are rotated every 90 days or less |
+| 2.8.6 | Google | Ensure That There Are Only GCP-Managed Service Account Keys for Each Service Account |
 
 ---
 

--- a/Cloud App and Config Profile/Cloud App and Config Test Guide.md
+++ b/Cloud App and Config Profile/Cloud App and Config Test Guide.md
@@ -126,6 +126,8 @@ Version 1.0 - 10-OCT 24
 
 [2.8.4 Ensure access keys are rotated every 90 days or less](#284-ensure-access-keys-are-rotated-every-90-days-or-less)
 
+[2.8.6 Ensure That There Are Only GCP-Managed Service Account Keys for Each Service Account](#286-ensure-that-there-are-only-gcp-managed-service-account-keys-for-each-service-account)
+
 [2.9 Use Unique Passwords](#29-use-unique-passwords)
 
 [2.9.1 Ensure IAM password policy prevents password reuse](#291-ensure-iam-password-policy-prevents-password-reuse)
@@ -2830,6 +2832,36 @@ aws iam get-credential-report --query 'Content' --output text | base64 -d
 **Verification**
 
 Evidence or test output indicates that no user has an active access key with the last rotated date greater than 90 days in the past.
+
+
+---
+
+### 2.8.6 Ensure That There Are Only GCP-Managed Service Account Keys for Each Service Account
+**Platform:** Google
+
+**Rationale:** User-managed service account keys increase the risk of credential exposure. GCP-managed keys are automatically rotated by Google and cannot be downloaded, reducing the attack surface.
+
+**External Reference:** CIS Google Cloud Platform Foundation Benchmark v4.0.0, Section 1.4
+
+**Evidence**
+
+**From Google Cloud Console:**
+
+1. Go to IAM & Admin > Service Accounts
+2. For each service account, click on the account and go to the Keys tab
+3. Ensure no keys of type `USER_MANAGED` exist
+
+**From Google Cloud CLI:**
+
+```
+gcloud iam service-accounts keys list --iam-account=<sa-email> --managed-by=user
+```
+
+If any keys are returned, user-managed keys exist for that service account.
+
+**Verification**
+
+Evidence or test output indicates that no service accounts have user-managed keys.
 
 
 ---

--- a/cloud-assessment/ada_cloud_audit/checks/gcp/iam.py
+++ b/cloud-assessment/ada_cloud_audit/checks/gcp/iam.py
@@ -1,6 +1,6 @@
 """GCP IAM checks for ADA Cloud assessment.
 
-Covers 7 requirements:
+Covers 8 requirements:
 - 2.3.5: Essential Contacts configured for organization
 - 2.6.1: Secrets not stored in Cloud Functions env vars
 - 2.7.5: IAM users not assigned SA User/Token Creator roles at project level
@@ -8,6 +8,7 @@ Covers 7 requirements:
 - 2.11.5: Service accounts have no admin privileges
 - 2.12.1: Corporate login credentials used (no @gmail.com)
 - 2.14.7: MFA enabled for all non-service accounts (INCONCLUSIVE)
+- 2.8.6: Only GCP-managed service account keys
 """
 
 from __future__ import annotations
@@ -295,3 +296,44 @@ def check_mfa_non_service(session: GCPSession) -> RequirementResult:
         "Manual verification required: check Admin Console > Security > 2-Step Verification "
         "to confirm MFA is enforced for all non-service accounts.",
     )
+
+
+def check_gcp_managed_sa_keys(session: GCPSession) -> RequirementResult:
+    """ADA 2.8.6: Ensure only GCP-managed service account keys exist."""
+    spec_id = "2.8.6"
+    title = "Ensure That There Are Only GCP-Managed Service Account Keys for Each Service Account"
+
+    try:
+        from googleapiclient import discovery
+
+        service = discovery.build("iam", "v1", credentials=session.credentials)
+        sa_list = service.projects().serviceAccounts().list(
+            name=f"projects/{session.project_id}"
+        ).execute()
+
+        accounts = sa_list.get("accounts", [])
+        if not accounts:
+            return make_result(spec_id, title, "GCP", Verdict.PASS,
+                             "No service accounts found in the project")
+
+        violating = []
+        for sa in accounts:
+            email = sa.get("email", "")
+            keys_resp = service.projects().serviceAccounts().keys().list(
+                name=f"projects/{session.project_id}/serviceAccounts/{email}",
+                keyTypes=["USER_MANAGED"],
+            ).execute()
+            user_keys = keys_resp.get("keys", [])
+            if user_keys:
+                violating.append(f"{email} ({len(user_keys)} user-managed key(s))")
+
+        if violating:
+            return make_result(spec_id, title, "GCP", Verdict.FAIL,
+                             "Service accounts with user-managed keys:\n" + "\n".join(violating),
+                             {"violating": violating, "total_accounts": len(accounts)})
+        return make_result(spec_id, title, "GCP", Verdict.PASS,
+                         f"All {len(accounts)} service accounts use only GCP-managed keys",
+                         {"total_accounts": len(accounts)})
+    except Exception as e:
+        return make_result(spec_id, title, "GCP", Verdict.INCONCLUSIVE,
+                         f"Error checking service account keys: {e}")

--- a/cloud-assessment/ada_cloud_audit/checks/registry.py
+++ b/cloud-assessment/ada_cloud_audit/checks/registry.py
@@ -116,6 +116,7 @@ def _register_gcp_checks() -> None:
         "2.11.5": gcp_iam.check_sa_admin_privileges,
         "2.12.1": gcp_iam.check_corporate_credentials,
         "2.14.7": gcp_iam.check_mfa_non_service,
+        "2.8.6": gcp_iam.check_gcp_managed_sa_keys,
 
         # Logging (8 checks)
         "3.1.1": gcp_logging.check_cloud_asset_inventory,


### PR DESCRIPTION
## 🔗 Linked Issue
Fixes #270

## 📖 Summary of Changes
- Added new check **2.8.6**: Ensure That There Are Only GCP-Managed Service Account Keys for Each Service Account
- CIS v4 reference: Section 1.4 (Level 1, Automated)
- Added `check_gcp_managed_sa_keys()` in `gcp/iam.py`

## 📋 Requirement Verification
- [ ] The proposed requirement text matches the approved Issue.
- [ ] All automated tests/checks pass on the `develop` branch.

## ⚖️ Governance & Consensus
- [ ] **Consensus Reached:** The Working Group has reached a rough consensus on this change.
- [ ] **Voting:** If required, the formal vote has passed (Link to vote results: [URL]).
- [ ] **Reviewers:** At least two members of the Working Group have signed off on this PR.

## 📸 Additional Context
Part of the CIS GCP Foundation Benchmark v2 → v4 update effort.