### PR TITLE
Add KMS key rotation 90 days check (CIS v4 1.10)

### DIFF
--- a/Cloud App and Config Profile/Cloud App and Config Specification.md
+++ b/Cloud App and Config Profile/Cloud App and Config Specification.md
@@ -548,6 +548,7 @@ The principle of least privilege reduces the risk of unauthorized actions being 
 | 2.7.4 | Azure | Ensure That 'Guest users access restrictions' is set to 'Guest user access is restricted to properties and memberships of their own directory objects' |
 | 2.7.5 | Google | Ensure That IAM Users Are Not Assigned the Service Account User or Service Account Token Creator Roles at Project Level |
 | 2.7.6 | Google | Ensure That Cloud KMS Cryptokeys Are Not Anonymously or Publicly Accessible |
+| 2.7.9 | Google | Ensure KMS Encryption Keys Are Rotated Within a Period of 90 Days |
 
 
 ---

--- a/Cloud App and Config Profile/Cloud App and Config Test Guide.md
+++ b/Cloud App and Config Profile/Cloud App and Config Test Guide.md
@@ -116,6 +116,8 @@ Version 1.0 - 10-OCT 24
 
 [2.7.6 Ensure That Cloud KMS Cryptokeys Are Not Anonymously or Publicly Accessible](#276-ensure-that-cloud-kms-cryptokeys-are-not-anonymously-or-publicly-accessible)
 
+[2.7.9 Ensure KMS Encryption Keys Are Rotated Within a Period of 90 Days](#279-ensure-kms-encryption-keys-are-rotated-within-a-period-of-90-days)
+
 [2.8 Establish and Maintain a Secure Configuration Process](#28-establish-and-maintain-a-secure-configuration-process)
 
 [2.8.1 Ensure Security Defaults is enabled on Azure Active Directory](#281-ensure-security-defaults-is-enabled-on-azure-active-directory)
@@ -2646,6 +2648,43 @@ gcloud kms keys get-iam-policy [key_name] --keyring=[key_ring_name] --location=g
 **Verification**
 
 Evidence or test output indicates that cloud KML cryptokeys are not anonymously or publicly accessible.
+
+
+---
+
+### 2.7.9 Ensure KMS Encryption Keys Are Rotated Within a Period of 90 Days
+**Platform:** Google
+
+**Rationale:** Rotating encryption keys on a regular schedule limits the blast radius if a key is compromised. A 90-day rotation period ensures that data encrypted with a given key version is re-protected under a new key version within a known, bounded window, reducing the amount of data exposed by a single compromised key.
+
+**External Reference:** CIS Google Cloud Platform Foundation Benchmark v4.0.0, Section 1.10
+
+**Evidence**
+
+**From Google Cloud CLI**
+
+
+
+1. List all Cloud KMS `Cryptokeys`.
+
+
+```
+gcloud kms keys list --keyring=<keyring> --location=<location> --format=json
+```
+
+
+
+2. For each key, verify that `rotationPeriod` is set and is no longer than `7776000s` (90 days), and that `nextRotationTime` is set to a future date.
+
+
+```
+gcloud kms keys describe <key_name> --keyring=<keyring> --location=<location> --format=json | jq '{rotationPeriod, nextRotationTime}'
+```
+
+
+**Verification**
+
+Evidence or test output indicates that all KMS encryption keys have a rotation period of 90 days or less and a scheduled next rotation time.
 
 
 ---

--- a/cloud-assessment/ada_cloud_audit/checks/gcp/iam.py
+++ b/cloud-assessment/ada_cloud_audit/checks/gcp/iam.py
@@ -1,10 +1,11 @@
 """GCP IAM checks for ADA Cloud assessment.
 
-Covers 7 requirements:
+Covers 8 requirements:
 - 2.3.5: Essential Contacts configured for organization
 - 2.6.1: Secrets not stored in Cloud Functions env vars
 - 2.7.5: IAM users not assigned SA User/Token Creator roles at project level
 - 2.7.6: Cloud KMS cryptokeys not publicly accessible
+- 2.7.9: KMS encryption keys rotated within 90 days
 - 2.11.5: Service accounts have no admin privileges
 - 2.12.1: Corporate login credentials used (no @gmail.com)
 - 2.14.7: MFA enabled for all non-service accounts (INCONCLUSIVE)
@@ -295,3 +296,69 @@ def check_mfa_non_service(session: GCPSession) -> RequirementResult:
         "Manual verification required: check Admin Console > Security > 2-Step Verification "
         "to confirm MFA is enforced for all non-service accounts.",
     )
+
+
+# Maximum allowed rotation period: 90 days in seconds
+_MAX_ROTATION_PERIOD_SECONDS = 7776000
+
+
+def check_kms_key_rotation(session: GCPSession) -> RequirementResult:
+    """ADA 2.7.9: Ensure KMS encryption keys are rotated within 90 days."""
+    spec_id = "2.7.9"
+    title = "Ensure KMS encryption keys are rotated within a period of 90 days"
+
+    try:
+        from google.cloud import kms_v1
+        from google.protobuf import duration_pb2  # noqa: F401
+
+        client = kms_v1.KeyManagementServiceClient(credentials=session.credentials)
+
+        parent = f"projects/{session.project_id}/locations/-"
+        non_compliant = []
+        total_keys = 0
+
+        try:
+            for key_ring in client.list_key_rings(parent=parent):
+                for crypto_key in client.list_crypto_keys(parent=key_ring.name):
+                    # Only symmetric encrypt/decrypt keys support automatic rotation
+                    if crypto_key.purpose != kms_v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT:
+                        continue
+
+                    total_keys += 1
+                    rotation_period = crypto_key.rotation_period
+                    next_rotation_time = crypto_key.next_rotation_time
+
+                    if not rotation_period or rotation_period.total_seconds() == 0:
+                        non_compliant.append(
+                            f"{crypto_key.name}: no rotation period configured"
+                        )
+                    elif rotation_period.total_seconds() > _MAX_ROTATION_PERIOD_SECONDS:
+                        days = int(rotation_period.total_seconds() / 86400)
+                        non_compliant.append(
+                            f"{crypto_key.name}: rotation period is {days} days (>90)"
+                        )
+                    elif not next_rotation_time:
+                        non_compliant.append(
+                            f"{crypto_key.name}: no next rotation time scheduled"
+                        )
+        except Exception as e:
+            if "PERMISSION_DENIED" in str(e) or "403" in str(e):
+                return make_result(spec_id, title, "GCP", Verdict.INCONCLUSIVE,
+                                 f"Insufficient permissions to list KMS keys: {e}")
+            raise
+
+        if total_keys == 0:
+            return make_result(spec_id, title, "GCP", Verdict.PASS,
+                             "No symmetric Cloud KMS encryption keys found")
+
+        if non_compliant:
+            return make_result(spec_id, title, "GCP", Verdict.FAIL,
+                             "KMS keys not rotated within 90 days:\n" + "\n".join(non_compliant),
+                             {"non_compliant": non_compliant, "total_keys": total_keys})
+
+        return make_result(spec_id, title, "GCP", Verdict.PASS,
+                         f"All {total_keys} symmetric KMS keys have rotation period <= 90 days",
+                         {"total_keys": total_keys})
+    except Exception as e:
+        return make_result(spec_id, title, "GCP", Verdict.INCONCLUSIVE,
+                         f"Error checking KMS key rotation: {e}")

--- a/cloud-assessment/ada_cloud_audit/checks/registry.py
+++ b/cloud-assessment/ada_cloud_audit/checks/registry.py
@@ -108,11 +108,12 @@ def _register_gcp_checks() -> None:
         "1.7.1": gcp_compute.check_serial_port,
         "1.8.2": gcp_compute.check_oslogin,
 
-        # IAM (7 checks)
+        # IAM (8 checks)
         "2.3.5": gcp_iam.check_essential_contacts,
         "2.6.1": gcp_iam.check_secrets_in_functions,
         "2.7.5": gcp_iam.check_sa_user_role,
         "2.7.6": gcp_iam.check_kms_public_access,
+        "2.7.9": gcp_iam.check_kms_key_rotation,
         "2.11.5": gcp_iam.check_sa_admin_privileges,
         "2.12.1": gcp_iam.check_corporate_credentials,
         "2.14.7": gcp_iam.check_mfa_non_service,


### PR DESCRIPTION
## Summary

- Add spec entry 2.7.9 for GCP KMS key rotation within 90 days
- Add test procedure with `gcloud kms keys` CLI evidence steps
- Implement `check_kms_key_rotation` in `gcp/iam.py` using `kms_v1` to verify rotation period <= 7776000s (90 days) for symmetric ENCRYPT_DECRYPT keys
- Register check 2.7.9 in the GCP provider registry

Fixes #272

**External Reference:** CIS Google Cloud Platform Foundation Benchmark v4.0.0, Section 1.10 (Level 1, Automated)

## Test plan

- [ ] Verify spec table includes 2.7.9 entry under section 2.7
- [ ] Verify Test Guide ToC and section for 2.7.9 are correctly placed
- [ ] Verify `check_kms_key_rotation` returns PASS when all keys have rotation_period <= 90 days
- [ ] Verify `check_kms_key_rotation` returns FAIL when any key has rotation_period > 90 days or no rotation configured
- [ ] Verify `check_kms_key_rotation` returns INCONCLUSIVE on permission errors
- [ ] Verify registry maps 2.7.9 to the new check function