### PR TITLE
Fix Azure provider parsing, fail fast on auth, and quiet Azure SDK logs

### DIFF
--- a/cloud-assessment/ada_cloud_audit/cli.py
+++ b/cloud-assessment/ada_cloud_audit/cli.py
@@ -94,14 +94,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def run_assessment(args: argparse.Namespace) -> AssessmentReport:
     """Run all checks for the specified provider and return the assessment report."""
-    provider = Provider(args.provider.upper())
+    provider = Provider[args.provider.upper()]
 
     # Create provider-specific session
     if provider == Provider.AZURE:
+
+        logging.getLogger("azure").setLevel(logging.ERROR)
+        logging.getLogger("azure.identity").setLevel(logging.ERROR)
+        logging.getLogger("azure.core").setLevel(logging.ERROR)
+
         from azure.identity import DefaultAzureCredential
         from ada_cloud_audit.checks.azure.base import AzureSession
 
         credential = DefaultAzureCredential()
+        try:
+            credential.get_token("https://management.azure.com/.default")
+        except Exception as e:
+            logger.error("Azure authentication failed (could not acquire ARM token): %s", e)
+            sys.exit(1)
+
         subscription_id = args.subscription or os.environ.get("AZURE_SUBSCRIPTION_ID")
         if not subscription_id:
             logger.error("Azure subscription ID required. Use --subscription or set AZURE_SUBSCRIPTION_ID.")

--- a/cloud-assessment/pyproject.toml
+++ b/cloud-assessment/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ada-cloud-audit"
 version = "0.1.0"
 description = "ADA Cloud App and Config assessment automation tool"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dependencies = [
     "boto3>=1.26.0",
     "python-docx>=0.8.11",
@@ -29,7 +29,7 @@ azure = [
     "azure-mgmt-redis>=14.0",
     "azure-mgmt-resource>=23.0",
     "azure-mgmt-security>=5.0",
-    "azure-mgmt-sql>=4.0",
+    "azure-mgmt-sql>=4.0.0b1,<4.0.1",
     "azure-mgmt-storage>=21.0",
     "azure-mgmt-web>=7.0",
     "azure-keyvault-keys>=4.8",


### PR DESCRIPTION
- Parse --provider via Provider[...] to match enum names (avoids ValueError)
- Reduce noisy azure/azure.identity/azure.core logging during credential chain attempts
- Preflight Azure auth by acquiring an ARM token and exit(1) immediately on failure
- Adjust azure extra to allow azure-mgmt-sql 4.0 prerelease builds (>=4.0.0b1,<4.0.1)

## 🔗 Linked Issue
Fixes # ## 📖 Summary of Changes
## 📋 Requirement Verification
- [ ] The proposed requirement text matches the approved Issue.
- [ ] All automated tests/checks pass on the `develop` branch.

## ⚖️ Governance & Consensus
- [ ] **Consensus Reached:** The Working Group has reached a rough consensus on this change.
- [ ] **Voting:** If required, the formal vote has passed (Link to vote results: [URL]).
- [ ] **Reviewers:** At least two members of the Working Group have signed off on this PR.

## 📸 Additional Context
