### PR TITLE
Retire embedded Revision History tables from MASA, CASA, and Cloud specs

### DIFF
--- a/CASA/CASA Specification.md
+++ b/CASA/CASA Specification.md
@@ -1,14 +1,7 @@
 # App Defense Alliance CASA Specification
-Version 1.0 - 10-OCT 24
+Version 2.2.0 - 2026-06-02
 
-
-# Revision History
-| Version | Date  | Description|
-|----|----|-----------------|
-| 0.5 | 5/25/24 | Initial draft based on Web App Tiger Team review of ASVS specification |
-| 0.7 | 5/25/24 | Updates from Tiger Team review of 0.5 spec |
-| 0.9 | 8/9/24 | Updates from ASA WG leads review of 0.7 spec |
-| 1.0 | 10-OCT 24 | Approved for release by the alliance steering committee |
+> **Version history** is maintained via [GitHub Releases](https://github.com/appdefensealliance/ASA-WG/releases) and [`CHANGELOG.md`](../CHANGELOG.md).
 
 # Contributors
 The App Defense Alliance Application Security Assessment Working Group (ASA WG) would like to thank the following individuals for their contributions to this specification.

--- a/CASA/CASA Test Guide.md
+++ b/CASA/CASA Test Guide.md
@@ -1,14 +1,7 @@
 # App Defense Alliance CASA Testing Guide
-Version 1.0 - 10-OCT 24
+Version 2.2.0 - 2026-06-02
 
-
-# Revision History
-| Version | Date  | Description|
-|----|----|-----------------|
-| 0.5 | 25-MAY 24 | Initial draft based on Web App Tiger Team review of ASVS specification |
-| 0.7 | 25-MAY 24 | Updates from Tiger Team review of 0.5 spec |
-| 0.9 | 9-AUG 24 | Updates from ASA WG leads review of 0.7 spec |
-| 1.0 | 10-OCT 24 | Approved for release by the alliance steering committee |
+> **Version history** is maintained via [GitHub Releases](https://github.com/appdefensealliance/ASA-WG/releases) and [`CHANGELOG.md`](../CHANGELOG.md).
 
 # About This Guide
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 _Changes targeting the next release (v2.0.0)._
 
 ### Changed
+- Removed embedded Revision History tables from MASA, CASA, and Cloud App & Config spec documents; version history is now tracked via GitHub Releases and CHANGELOG.md
 - Rebranding Mobile App Profile from ASA to MASA v2 (#212)
 - Rebranding Web App Profile from ASA to CASA v2 (#213)
 - Removed proficiency exam requirements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ When the WG is ready to propose a release:
 2. **Update `CHANGELOG.md`** on the release branch:
    - Move items from `[Unreleased]` to the new version section.
    - Include the date and a summary of all changes.
+   - Update the top-of-file version stamp in each changed spec to the target release version.
 3. **Open a PR targeting `main`** from the release branch.
    - Title: `Release vX.Y.Z`
    - Body: Summary of all included WG PRs and their issue references.
@@ -86,6 +87,10 @@ This project uses [Semantic Versioning](https://semver.org/):
 - **Major** (e.g., `v2.0.0`): Significant changes to profiles, new profiles, or breaking changes to existing requirements.
 - **Minor** (e.g., `v1.1.0`): New requirements added, non-breaking modifications to existing requirements.
 - **Patch** (e.g., `v1.0.1`): Clarifications, typo fixes, editorial corrections that do not change the substance of any requirement.
+
+### Document versioning
+
+Per-document **Revision History tables are not maintained**. The canonical change history is GitHub Releases (semver tags on `main`) and `CHANGELOG.md`. Each published artifact carries a single `Version X.Y.Z — DATE` stamp at the top so standalone copies remain citable; this stamp is updated on the release branch during Stage 3 (alongside the `CHANGELOG.md` update) and reflects the release tag applied in Stage 4.
 
 ## Consensus & Voting
 

--- a/Cloud App and Config Profile/Cloud App and Config Specification.md
+++ b/Cloud App and Config Profile/Cloud App and Config Specification.md
@@ -1,14 +1,8 @@
 # App Defense Alliance Cloud Profile
 ## Specification
-Version 1.0 - 10-OCT 24
+Version 2.2.0 - 2026-06-02
 
-# Revision History
-| Version | Date  | Description|
-|----|----|-----------------|
-| 0.5 | 8-MAY 24 | Initial draft based on Web App Tiger Team review of CIS Cloud Foundations Benchmarks |
-| 0.7 | 25-MAY 24 | Updates from Tiger Team review of 0.5 spec |
-| 0.9 | 9-AUG 24 | Updates from ASA WG leads review of 0.7 spec |
-| 1.0 | 10-OCT 24 | Approved for release by the alliance steering committee |
+> **Version history** is maintained via [GitHub Releases](https://github.com/appdefensealliance/ASA-WG/releases) and [`CHANGELOG.md`](../CHANGELOG.md).
 
 
 # Contributors

--- a/MASA/MASA Specification.md
+++ b/MASA/MASA Specification.md
@@ -1,16 +1,9 @@
 
 # App Defense Alliance MASA Specification
 
-Version 1.0 - 10-OCT 24
+Version 2.2.0 - 2026-06-02
 
-## Revision History
-
-| Version | Date | Description |
-| --- | :--- | :--- |
-| 0.5 | 10-MAY 24 | Initial draft based on Mobile App Tiger Team review of MASVS specification |
-| 0.7 | 25-MAY 24 | Updates from Tiger Team review of 0.5 spec |
-| 0.9 | 9-AUG 24 | Updates from ASA WG leads review of 0.7 spec |
-| 1.0 | 10-OCT 24 | Approved for release by the alliance steering committee |
+> **Version history** is maintained via [GitHub Releases](https://github.com/appdefensealliance/ASA-WG/releases) and [`CHANGELOG.md`](../CHANGELOG.md).
 
 ## Acknowledgements
 

--- a/MASA/MASA Test Guide.md
+++ b/MASA/MASA Test Guide.md
@@ -1,15 +1,8 @@
 # App Defense Alliance MASA Testing Guide
 
-Version 1.0 - 10-OCT 24
+Version 2.2.0 - 2026-06-02
 
-## Revision History
-
-| Version | Date | Description |
-| --- | :--- | :--- |
-| 0.5 | 5/10/24 | Initial draft based on Mobile App Tiger Team review of MASVS specification |
-| 0.7 | 5/25/24 | Updates from Tiger Team review of 0.5 spec |
-| 0.9 | 8/9/24 | Updates from ASA WG leads review of 0.7 spec |
-| 1.0 | 10-OCT 24 | Approved for release by the alliance steering committee |
+> **Version history** is maintained via [GitHub Releases](https://github.com/appdefensealliance/ASA-WG/releases) and [`CHANGELOG.md`](../CHANGELOG.md).
 
 ## Contributors
 The App Defense Alliance Application Security Assessment Working Group (ASA WG) would like to thank the following individuals for their contributions to this specification:


### PR DESCRIPTION
## Summary

Per the team's move to GitHub-native lifecycle management (semver tags + `CHANGELOG.md`, per `CONTRIBUTING.md`), this removes the now-redundant per-document **Revision History tables** from the MASA, CASA, and Cloud spec documents. The embedded tables had already drifted — all still read `1.0 / 10-OCT 24` despite the repo shipping `v2.0.0` and `v2.1.0` — creating a dual source of truth and ongoing maintenance burden.

Each document keeps a single top-of-file version stamp (now `Version 2.2.0 - 2026-06-02`) so standalone/PDF copies remain citable, with a pointer to the canonical history.

## Changes

**Spec docs (5)** — removed the Revision History table, added a pointer line, refreshed the version stamp:
- `CASA/CASA Specification.md`
- `CASA/CASA Test Guide.md`
- `MASA/MASA Specification.md`
- `MASA/MASA Test Guide.md`
- `Cloud App and Config Profile/Cloud App and Config Specification.md`

**Governance**
- `CONTRIBUTING.md` — new `### Document versioning` subsection + a Stage 3 step to bump each spec's version stamp at release time.
- `CHANGELOG.md` — logged under `[Unreleased] → Changed`.

## Out of scope
- Unreleased Meta Platform Extension drafts (`v0.5 DRAFT`) — being fast-tracked separately into v2.2.
- `AI Profile/AI Tool Specification.md` — deferred to a later batch.

## Notes for reviewers
- The `2.2.0` stamp assumes this lands in the v2.2 release; if the version slips, it's a one-line fix per doc (and per the new convention, set definitively on the release branch in Stage 3).