### PR TITLE
fix(AI Profile): resolve Contract C2 data/control-separation obligation (Option A) — Fixes #372

### DIFF
--- a/AI Profile/AI Agent-Tool Interface Contract.md
+++ b/AI Profile/AI Agent-Tool Interface Contract.md
@@ -37,10 +37,10 @@ Enacts the confused-deputy defense across the boundary. Tool-side obligations ar
 
 ## C2 — Data / Control Separation
 
-* **Tool obligation:** The Tool MUST return external/retrieved content tagged with provenance and segregated from tool-control fields, so that the Agent can distinguish data from instructions. The Tool MUST NOT embed control directives intended for the model within operation results.  
-* **Agent obligation:** The Agent MUST treat all Tool Output as untrusted data and MUST NOT interpret it as instructions. Tool Output MUST NOT, on its own, cause the Agent to invoke a Sensitive Action without fresh user consent (C3).
+* **Tool obligation:** The Tool MUST NOT embed model-directed control directives or instructions within its operation results, tool/function descriptions, or schemas, and MUST NOT rely on the model or Agent to enforce the Tool's own security constraints. The Tool SHOULD, where feasible, return structured/typed output and MAY tag external/retrieved content with provenance as defense-in-depth; producer-supplied tags MUST NOT be relied upon by the Agent as a security boundary (a malicious or compromised Tool will not tag honestly).  
+* **Agent obligation (load-bearing):** The Agent MUST treat all Tool Output — including operation results, retrieved/resource content, and tool/function descriptions and schemas — as untrusted data and MUST NOT interpret it as instructions. Tool Output MUST NOT, on its own, cause the Agent to invoke a Sensitive Action without fresh user consent (C3).
 
-Enacts the defense against indirect prompt injection delivered through tool content. Tool-side provenance tagging is specified in AI Tool Specification §6.1; Agent-side handling is tested in AI Agent Specification §3.1.2 against the Malicious Reference Tool.
+Enacts the defense against indirect prompt injection delivered through tool content. This is primarily a **consumer-side** control: the load-bearing defense is the Agent obligation above, tested in AI Agent Specification §3.1.2 against the Malicious Reference Tool. AI Tool Specification §6.1 correctly defers *mitigation* of resource-content poisoning to the Agent; the narrow Tool-side honest-behaviour duty is specified in AI Tool Specification §6.1.1. This allocation follows CoSAI MCP Security §3.2.3/§3.2.8 and OWASP Top 10 for Agentic Applications 2026 ASI01/ASI02, which assign data/control separation to the agent/host; no reviewed framework imposes a producer-side provenance duty.
 
 ## C3 — Consent for Consequential Actions
 

--- a/AI Profile/AI Tool Specification.md
+++ b/AI Profile/AI Tool Specification.md
@@ -781,7 +781,32 @@ Improper validation of file paths or tool arguments enables access to or exfiltr
 
 Attackers embed hidden malicious instructions within data sources (databases, documents, API responses) that MCP servers retrieve and provide to LLMs, causing the poisoned content to execute as commands when processed, effectively achieving persistent prompt injection through trusted data channels rather than direct user input. Unlike Prompt Injection (MCP-12): Malicious instructions are embedded in backend data sources, not user-provided prompts. Unlike Tool Poisoning (MCP-2): Poisons the actual data/content retrieved by tools, not the tool definitions themselves. This attack surface may be expanded with transitive or composed MCP server calls.
 
-**Note: Mitigations for this risk are out of scope for the AI Tool specification. This threat will be addressed in the AI Agent specification.**
+**Note:** *Mitigation of the resource-content-poisoning attack* — treating retrieved/external content as untrusted so it cannot act as an instruction — is a **consumer-side** control performed by the AI Agent (AI Agent Specification §3.1.2; Agent–Tool Interface Contract C2 Agent obligation), not by the AI Tool. Indirect prompt injection cannot be prevented by the producer marking its output: a benign Tool cannot reliably distinguish embedded instructions from data, and a malicious Tool will not tag honestly (CoSAI MCP Security §6.2, MCP-T4). The AI Tool carries only the narrow, verifiable honest-behaviour duty in §6.1.1 below.
+
+### 6.1.1 No Embedded Model-Directed Control Directives
+
+#### Description
+
+The AI Tool MUST NOT embed model-directed control directives or instructions within the content it returns to the Agent — including operation results, retrieved/resource content, and its own tool/function descriptions and schemas. The AI Tool MUST NOT rely on the model or Agent to enforce the Tool's own security constraints; it MUST validate its own inputs and enforce its own authorization independently of the model. The AI Tool MAY provide provenance or "data vs. control" tags as defense-in-depth, but these MUST NOT be relied upon as a security boundary.
+
+#### Rationale
+
+Indirect prompt injection is not preventable by the producer marking its output (a benign Tool cannot reliably separate instructions from data in arbitrary content, and a malicious Tool will not tag honestly), so the load-bearing defence is the Agent treating all Tool Output as untrusted (Agent–Tool Interface Contract C2 Agent obligation; AI Agent Specification §3.1.2). The Tool's residual, testable duty is simply not to be an injection vector itself and not to delegate its own security to the model — consistent with CoSAI MCP Security §3.2.8: "Tool implementations should not rely on the LLM to perform security-critical operations, validate inputs, or enforce constraints."
+
+#### Audit
+
+| Method | Description |
+| :---- | :---- |
+| Static | Review tool/function descriptions, schemas, and output-construction code to confirm no imperative instructions directed at the model are embedded (e.g., "ignore previous instructions", role/turn markers, tool-chaining commands). Confirm input validation and authorization are enforced in Tool code and do not depend on model cooperation. |
+| Dynamic | Exercise the Tool and inspect returned content, descriptions, and schemas for embedded model-directed instructions or control tokens. Confirm the Tool rejects invalid or unauthorized requests regardless of any accompanying natural-language content. |
+
+#### Comments
+
+| Scope | Comment |
+| :---- | :---- |
+| Local | In scope |
+| Mobile | In scope |
+| Remote | In scope |
 
 ## 6.2 Typosquatting/Confusion Attacks 
 


### PR DESCRIPTION
## 🔗 Linked Issue
Fixes #372

## 📖 Summary of Changes
Resolves the **C2 (Data/Control Separation)** contradiction: the contract pointed the Tool-side provenance duty at **AI Tool Spec §6.1**, which is explicitly *out of scope / deferred to the Agent*. Implements **Option A (Agent-primary + narrow Tool duty)**, which six source frameworks unanimously support (see issue for verbatim citations).

**`AI Agent-Tool Interface Contract.md` (C2):**
- Agent obligation marked **load-bearing** and broadened to explicitly include tool/function descriptions and schemas.
- Tool obligation **narrowed** to: MUST NOT embed model-directed control directives/instructions in results, descriptions, or schemas; MUST NOT rely on the model to enforce the Tool's own constraints.
- Provenance/segregation **downgraded to SHOULD** (defense-in-depth, explicitly not a security boundary — a malicious Tool won't tag honestly).
- Footer corrected: no longer cites §6.1 as the tool-side source; attributes the allocation to CoSAI §3.2.3/§3.2.8 and OWASP Agentic Top 10 2026 ASI01/ASI02.

**`AI Tool Specification.md` (§6.1):**
- Reworded the note: *mitigation* of resource-content poisoning is a **consumer-side** control (Agent Spec §3.1.2 / Contract C2 Agent obligation).
- Added **§6.1.1 "No Embedded Model-Directed Control Directives"** — the narrow, testable Tool duty, in the spec's standard Description/Rationale/Audit/Comments format.

## 📋 Requirement Verification
- [ ] The proposed requirement text matches the approved Issue (#372).
- [x] Change is grounded in verbatim citations from 6 source frameworks (documented in the issue).

## ⚖️ Governance & Consensus
- [ ] **Consensus Reached:** Normative change — WG rough consensus required.
- [ ] **Voting:** May require a vote (Requirement Modification).
- [ ] **Reviewers:** At least two WG members to sign off.

## 📸 Additional Context
Part of a series resolving contract↔spec contradictions surfaced after #365/#359 merged. Sibling item **C3 (§2.1 "Req TBD")** will follow as a separate issue/PR.
