### PR TITLE
fix(AI Profile): resolve Contract C3 consent obligation (C3-A) — Fixes #375

### DIFF
--- a/AI Profile/AI Agent-Tool Interface Contract.md
+++ b/AI Profile/AI Agent-Tool Interface Contract.md
@@ -44,10 +44,12 @@ Enacts the defense against indirect prompt injection delivered through tool cont
 
 ## C3 — Consent for Consequential Actions
 
-* **Tool obligation:** The Tool MUST classify each exposed operation by sensitivity and reversibility, and MUST emit a machine-readable `consent_required` signal for any Sensitive Action. The Tool MUST NOT execute a Sensitive Action without a consent assertion bound to the verified identity (C1) and the operation parameters.  
-* **Agent obligation:** The Agent MUST obtain and enforce per-action user consent for any operation flagged `consent_required`, MUST bind that consent to identity and parameters, and MUST record it with a correlation ID for audit.
+* **Agent obligation (primary, load-bearing):** The Agent MUST present, obtain, and enforce per-action user consent for any Sensitive Action, MUST bind that consent to the verified user identity (C1) and the operation parameters, and MUST record it with a correlation ID for audit. The user consent decision is made at the Agent's human interface.  
+* **Tool obligation (defense-in-depth backstop):** The Tool MUST classify each exposed operation by sensitivity and reversibility and, for a Sensitive Action, MUST either obtain user confirmation via server-side elicitation or fail closed. The Tool MUST NOT execute a Sensitive Action on the Agent's assertion alone that consent was obtained.
 
-Enacts informed consent at the consequential-action boundary. Tool-side obligations are specified in AI Tool Specification §2.1; Agent-side obligations in AI Agent Specification §2.2.
+Enacts informed consent at the consequential-action boundary. Consent enforcement is **primarily consumer-side** (CoSAI MCP Security §3.2.9; OWASP Top 10 for Agentic Applications 2026 ASI02/ASI09), with the Tool acting as a fail-closed backstop against a confused or malicious Agent — the confused-deputy case the Malicious Reference Agent tests. Agent-side obligations are specified in AI Agent Specification §2.2 (§2.2.2); Tool-side obligations in AI Tool Specification §2.1.1.
+
+**ADA extensions (beyond baseline MCP):** the machine-readable `consent_required` signal is an ADA construct (candidate alignment: MCP tool annotations); a consent assertion cryptographically bound to the verified user identity and operation parameters — letting the Tool verify consent without an interactive round-trip — is **deferred to the ADA identity/consent wire format together with C1**.
 
 # Reference Adversaries
 

--- a/AI Profile/AI Tool Specification.md
+++ b/AI Profile/AI Tool Specification.md
@@ -494,30 +494,36 @@ In the MCP architecture, the session token is the "keys to the kingdom." If a de
 
 Missing or insufficient human-in-the-loop consent checks can allow an MCP server to take risky actions not authorized by the user.
 
-### 2.1.1 Req TBD
+### 2.1.1 Server-Side Consent Backstop for Sensitive Actions
 
 #### Description
 
-TBD
+Primary responsibility for presenting, obtaining, and enforcing user consent for a Sensitive Action rests with the AI Agent (AI Agent Specification §2.2; Agent–Tool Interface Contract C3). As a fail-closed backstop that does not rely on the Agent having obtained consent, the AI Tool MUST, for any operation it classifies as a Sensitive Action:
+
+* **Classify sensitivity and reversibility.** Identify which exposed operations are Sensitive Actions — those that are irreversible, transfer value or money, mutate or share user data beyond the current task, or grant or expand access.
+* **Confirm via server-side elicitation, or fail closed.** Use elicitation (or an equivalent server-side confirmation) to request explicit user confirmation of the Sensitive Action, or enforce the use of clients configured so that unprivileged users cannot disable confirmation prompts. The confirmation message MUST clearly and unambiguously state the security implications of the action.
+* **Not defer to the Agent alone.** The Tool MUST NOT treat an Agent-supplied claim that "consent was obtained" as sufficient; it MUST fail closed when it cannot establish that the user confirmed the specific action.
+
+**ADA extensions (future revisions).** The Tool MAY emit a machine-readable `consent_required` signal for Sensitive Actions (an ADA construct; candidate alignment with MCP tool annotations). A consent assertion cryptographically bound to the verified user identity and operation parameters — enabling the Tool to verify consent without an interactive round-trip — is **deferred to the ADA identity/consent wire format** (tracked with the identity-propagation work) and is not required in this revision.
 
 #### Rationale
 
-TBD
+An AI Tool is invoked by an Agent it cannot fully trust: a confused or compromised Agent may drive a Sensitive Action the user never approved — the confused-deputy case exercised by the ADA Malicious Reference Agent. Consent presentation and enforcement are therefore primarily an Agent/host duty, but the Tool retains a fail-closed backstop so a malicious Agent cannot cause an irreversible action without a user gate. Server-side elicitation is the consent mechanism endorsed for MCP servers (CoSAI MCP Security §3.2.9; OWASP "A Practical Guide for Secure MCP Server Development" §4). User-approval *fatigue* (habituation from excessive prompts) remains an Agent-side concern (see §9.2).
 
 #### Audit
 
-| Method  | Description |
-| :------ | :---------- |
-| Static  |             |
-| Dynamic |             |
+| Method | Description |
+| :---- | :---- |
+| Static | Identify operations that qualify as Sensitive Actions. Verify the Tool mandates a server-side elicitation/confirmation (or enforces non-disableable client confirmation) before executing them, and does not execute a Sensitive Action solely on an Agent-supplied "consent obtained" claim. Verify confirmation messages state the action's implications. |
+| Dynamic | Using the ADA Malicious Reference Agent (or equivalent), attempt to trigger a Sensitive Action with forged or absent consent. Verify the Tool requests confirmation via elicitation or fails closed, and does not execute the action. |
 
 #### Comments
 
-| Scope  | Comment |
-| :----- | :------ |
-| Local  |         |
-| Mobile |         |
-| Remote |         |
+| Scope | Comment |
+| :---- | :---- |
+| Local | In scope |
+| Mobile | In scope |
+| Remote | In scope |
 
 ## 2.2 Improper Multitenancy
 
@@ -1041,7 +1047,7 @@ Overly permissive tools may expose the user’s data, or result in actions which
 
 Flooding users with excessive consent or permission prompts, causing habituation and leading to blind approval of potentially dangerous or malicious actions.
 
-**Note: User approval and user approval fatigue is out of scope for the AI Tool specification and is addressed in the AI Agent specification.**
+**Note:** User approval *fatigue* (habituation from an excessive volume of prompts) is out of scope for the AI Tool specification and is addressed in the AI Agent specification. The AI Tool's fail-closed consent backstop for Sensitive Actions is specified in §2.1.1.
 
 
 # 10 Resource Management/Rate Limiting Absence


### PR DESCRIPTION
## 🔗 Linked Issue
Fixes #375

## 📖 Summary of Changes
Resolves **C3 (Consent for Consequential Actions)**, which pointed the Tool-side obligation at **AI Tool Spec §2.1 ("Req TBD")**, contradicted **§9.2** ("user approval … out of scope for the AI Tool"), and assumed two non-baseline-MCP constructs. Implements **C3-A (Agent-primary consent + Tool defense-in-depth backstop)** — see the issue for verbatim citations from five sources.

**`AI Agent-Tool Interface Contract.md` (C3):**
- **Agent obligation = primary/load-bearing** (present, obtain, enforce per-action, bind to identity+params, record with correlation ID; decision at the Agent's human interface).
- **Tool obligation = fail-closed backstop** (classify sensitivity/reversibility; server-side **elicitation** or **fail closed**; never execute on the Agent's say-so alone) — the confused-deputy case the **MRA** tests.
- **`consent_required`** labeled an **ADA extension**; the **identity-bound consent assertion deferred** to the ADA identity/consent wire format (with C1). Pointer fixed to §2.1.1.

**`AI Tool Specification.md`:**
- **§2.1.1** — replaced "Req TBD" with **"Server-Side Consent Backstop for Sensitive Actions"** (substance promoted from the merged Tool Testing Guide §2.3; standard Description/Rationale/Audit/Comments; MRA-tested).
- **§9.2** — narrowed the note to user-approval **fatigue** (Agent-side) and pointed the Tool consent backstop to §2.1.1, removing the contradiction with C3.

## 📋 Requirement Verification
- [ ] The proposed requirement text matches the approved Issue (#375).
- [x] Grounded in verbatim citations from 5 sources (documented in the issue); tool-side mechanism = server-side elicitation (CoSAI §3.2.9 / OWASP MCP Dev §4).

## ⚖️ Governance & Consensus
- [ ] **Consensus Reached:** Normative change — WG rough consensus required.
- [ ] **Voting:** May require a vote (Requirement Modification).
- [ ] **Reviewers:** At least two WG members to sign off.

## 📸 Additional Context
Third in the series resolving contract↔spec contradictions after #365/#359 (following #373 for C2). Depends conceptually on the **identity/consent wire format (P0-3)** for the deferred consent-assertion tier.
