### PR TITLE
docs(AI Profile): define 'sensitive action' and 'AI model' in AI Tool Spec — Fixes #377

### DIFF
--- a/AI Profile/AI Tool Specification.md
+++ b/AI Profile/AI Tool Specification.md
@@ -213,8 +213,8 @@ This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 Inter
 
 | Term             | Definition |
 | :--------------- | :--------- |
-| sensitive action |            |
-| AI model         |            |
+| sensitive action | An operation that is irreversible, transfers value or money, mutates or shares user data beyond the scope of the current task, or grants or expands access. Aligned with "Sensitive Action" in the AI Agent–Tool Interface Contract. |
+| AI model | A statistical model — such as a large language model (LLM) — trained on data to perform inference (e.g., generating text, classifying inputs, or producing embeddings), that an AI Agent invokes or an AI Tool may use internally. |
 
 # 1 Improper Authentication and Identity Management
 ## 1.1 Identity Spoofing


### PR DESCRIPTION
## 🔗 Linked Issue
Fixes #377

## 📖 Summary of Changes
Fills the two blank entries in the **AI Tool Specification** Definitions table:
- **sensitive action** — replicated from the Agent–Tool Interface Contract's canonical **"Sensitive Action"** (with cross-reference), since it is the trigger for the C3 consent obligation and must stay consistent across documents.
- **AI model** — defined consistently with the AI Agent Spec's LLM definition and the Tool Spec's own usage (§3.3 integrity, §12 logging).

No requirement behaviour changes — this completes TBD placeholders with an already-agreed definition.

## 📋 Requirement Verification
- [x] "sensitive action" matches the contract's agreed "Sensitive Action" definition.
- [x] No normative behaviour change; definitions only.

## ⚖️ Governance & Consensus
- [ ] **Consensus Reached:** Low-controversy definitional fill — WG confirmation requested.
- [ ] **Reviewers:** At least two WG members to sign off.

## 📸 Additional Context
Part of the P0 series resolving gaps after #365/#359 (alongside #373 C2, #376 C3).
