### PR TITLE
rfc(AI Profile): Agent–Tool Identity & Consent Wire Format (D1) as an OPTIONAL profile — Fixes #379

### DIFF
--- a/AI Profile/AI Agent-Tool Identity and Consent Wire Format.md
+++ b/AI Profile/AI Agent-Tool Identity and Consent Wire Format.md
@@ -1,0 +1,203 @@
+# AI Agent–Tool Identity & Consent Wire Format
+
+> **Status: DRAFT / RFC — for Working Group feedback.** This document is a design proposal, not
+> ratified normative text. Sections marked **[OPEN DECISION]** require a WG determination, and the
+> **Pre-Normative Verification** checklist must be cleared before any requirement here becomes binding.
+> It is published together with issue **#379** to solicit feedback.
+
+## Purpose
+
+The Agent–Tool Interface Contract defines two invariants whose enforceable mechanism does not exist in
+baseline MCP and is currently undefined in the ADA specifications:
+
+- **C1 — Verifiable Identity Propagation:** the Agent forwards a per-user identity assertion the Tool can
+  cryptographically verify, bound per-action for Sensitive Actions.
+- **C3 — Consent for Consequential Actions (deferred tier):** a consent assertion bound to the verified
+  user identity and operation parameters (see AI Tool Specification §2.1.1, which defers this tier here).
+
+This profile defines that assertion format ("**D1**") so that the ADA Malicious Reference Tool (MRT) and
+Malicious Reference Agent (MRA) have a concrete artifact to exercise, and so that a Tool certified in
+isolation can verify identity/consent from any conformant Agent.
+
+## Relationship to MCP and existing standards
+
+- **Target revision: MCP 2025-11-25.** MCP has **no native message-signing/integrity mechanism** and (as of
+  2025-11-25) **no native per-user identity, consent, or scope field** on tools — confirmed against the core
+  base, tools, authorization, and elicitation specifications (extensions such as `modelcontextprotocol/ext-auth`
+  and SEPs are **not yet reviewed** — see *Pre-Normative Verification*). Identity/consent must therefore be
+  conveyed **in-band in the JSON-RPC message but outside the tool's `arguments`/`inputSchema`, as an
+  ADA-defined signed artifact.**
+- **Reuse over invention.** This profile reuses: OIDC (identity claim semantics), **IETF OAuth
+  Identity Assertion JWT Authorization Grant (ID-JAG), draft-04** (optional upstream identity source — see
+  below), RFC 8693 (token exchange / delegation), RFC 8707 + RFC 9068 + RFC 9728 (audience binding &
+  resource-server behaviour on HTTP), RFC 9396 (Rich Authorization Requests, per-action binding),
+  RFC 9449 (DPoP), RFC 7638 (JWK thumbprint), RFC 8785 (JCS canonicalization), and RFC 7515/7519 (JWS/JWT).
+
+## Carrier: `params._meta`
+
+- The assertions travel in the `tools/call` request's **`params._meta`** object. `_meta` is MCP's reserved
+  extension point and rides in the JSON-RPC message body, so it is carried **identically over stdio and
+  Streamable HTTP** — the only transport-agnostic placement. (OAuth/`Authorization` headers exist on
+  Streamable HTTP only; stdio has no headers.)
+- **Keys (reverse-DNS, per MCP's SHOULD):** `org.appdefensealliance/identity` (C1) and
+  `org.appdefensealliance/consent` (C3). Prefixes whose second label is `mcp`/`modelcontextprotocol` are
+  reserved for MCP; `org.appdefensealliance` is not. *(Verification task: confirm these sub-keys are not
+  reserved in `schema/2025-11-25/schema.ts`.)*
+- **Not in `arguments`.** The assertion MUST NOT be placed in `params.arguments`: it would collide with the
+  tool's `inputSchema`, be visible to the model, and risk being stripped by `additionalProperties:false`.
+- **Preservation requirement (ADA-defined).** MCP's base spec is **silent** on whether `_meta` is preserved
+  end-to-end through servers/gateways/proxies. This profile therefore REQUIRES that intermediaries forward
+  the `org.appdefensealliance/*` `_meta` keys **unchanged**. Because C1/C3 are **compact JWS/JWT (embedded
+  payload)**, tampering with the **assertion itself** is cryptographically detectable at the verifier. Note the
+  signature covers only the assertion's claims: the `tools/call` `name`/`arguments` are integrity-bound **only**
+  via the per-action binding, which is REQUIRED for Sensitive Actions — so for **non-Sensitive** calls the
+  arguments are **not** integrity-protected against a malicious intermediary (accept this residual risk, or
+  extend per-action binding to all calls — **[OPEN DECISION]**). The remaining risk is *silent stripping*
+  (availability), in which case the Tool MUST **fail closed**. *(Verification task: re-check the MCP
+  2025-11-25 transports/lifecycle pages for any preservation guarantee.)*
+
+## C1 — Identity Assertion (baseline, every Tool request)
+
+An ADA-defined, **tool-audience-bound** compact JWS/JWT.
+
+| Field | Value / meaning |
+|-------|-----------------|
+| `typ` (header) | `application/ada-identity+jwt` (distinct `typ` prevents cross-use) |
+| `alg` (header) | asymmetric allowlist only (e.g. `ES256`/`EdDSA`); `none` and `HS*` MUST be rejected |
+| `kid` (header) | key id into the issuer's JWKS/trust bundle |
+| `iss` | trusted IdP/issuer that authenticated the end user (on the Tool's pinned allowlist) |
+| `sub` | stable end-user identifier (used as `{JWT.sub}` for downstream scoping per Tool Spec §2.2.2) |
+| `aud` | **the specific target Tool / canonical MCP-server identifier** (defeats confused-deputy/redirection) |
+| `client_id` | the calling Agent |
+| `act` | `{ "sub": <agent/workload id> }` — RFC 8693 delegation (subject = user, actor = agent; no token passthrough) |
+| `iat`, `nbf`, `exp` | short lifetime (minutes); per-request freshness |
+| `jti` | unique id; Tool de-dupes for replay defense (pairs with Tool Spec §1.4) |
+| `cnf` | *(optional, RFC 7800)* PoP binding: `jkt` (JWK thumbprint, RFC 7638) for **DPoP** (RFC 9449), or `x5t#S256` for **mTLS** (RFC 8705) |
+| **per-action binding** | **REQUIRED for Sensitive Actions** — see below |
+
+**Per-action binding** (for Sensitive Actions), one of **[OPEN DECISION]**:
+- **RFC 9396 `authorization_details`** — structured (`type`/`actions`/`locations`/`identifier` + fields
+  pinning the actual arguments, e.g. amount, destination); auditable; Tool re-verifies each field. *(Favoured
+  for alignment with ID-JAG's RAR endorsement.)*
+- **`aph` (action-parameter hash)** — `base64url(SHA-256(JCS(bind_object)))` where
+  `bind_object = { tool: params.name, args: params.arguments, aud }` (`jti` is already a signed claim and is **not** folded into `aph`); opaque, simple (DPoP-`ath` style).
+
+## C3 — Consent Assertion (deferred tier; fills Tool Spec §2.1.1)
+
+Same envelope, `typ = application/ada-consent+jwt`. Binds the four things C3 requires:
+
+| Field | Meaning |
+|-------|---------|
+| `sub` | the SAME verified end user as C1 (consent tied to identity) |
+| `aud` + operation | the specific Tool + operation (consent bound to one action) |
+| per-action binding | `authorization_details` or `aph` — Tool recomputes and rejects on mismatch (defeats "consent to X, execute Y") |
+| `corr_id` | correlation ID for audit (satisfies the C3 Agent obligation to record) |
+| `jti`, `nbf`, `exp`, optional `cnf.jkt` | anti-replay |
+| `act` | agent as actor (RFC 8693) |
+
+**Relationship to MCP elicitation:** elicitation is the interactive *moment-of-consent trigger* only; its
+response carries **no signature or identity binding** (client-provided identity is forgeable), so it is
+**not** an acceptable consent receipt. The verifiable artifact is this signed C3 JWT.
+
+## Trust anchor / key distribution **[OPEN DECISION]**
+
+The Tool holds a **pinned issuer allowlist / trust bundle** (open `iss`-based discovery is forbidden).
+Verification key resolved by `kid`. Distribution options for WG choice:
+1. OIDC Discovery `jwks_uri` **constrained by the allowlist**;
+2. **SPIFFE** trust bundle + Federation (JWT-SVID for the agent/actor);
+3. an **ADA-run/endorsed registry or CA** (OWASP ANS-style PKI).
+Key rotation via `kid` + JWKS cache TTL with refresh-on-unknown-`kid` and an overlap window.
+
+## Tool-side verification algorithm
+
+1. Reject if `alg` not on the asymmetric allowlist (`none`/`HS*` → fail).
+2. Resolve key by `kid`; **`iss` MUST be on the pinned allowlist**; verify signature.
+3. Validate `aud` == this Tool, `exp`/`nbf`, and `jti` not previously seen (replay).
+4. For a Sensitive Action: recompute the per-action binding — for `aph`, JCS-hash the full
+   `bind_object` (`{ tool: params.name, args: params.arguments, aud }`); for `authorization_details`, match each
+   field against the **actual** `params.name`/`params.arguments` — and reject on mismatch.
+5. For C3: additionally require a valid Consent Assertion bound to the same `sub` + operation + parameters.
+6. Any failure → **hard-fail (`401`/`403`)**, fail closed. (MRA exercises forged/missing/mismatched/replayed
+   assertions against these steps.)
+
+## Relationship to ID-JAG (why it is upstream, not the wire artifact)
+
+ID-JAG (draft-04, IETF-WG-adopted) is a strong per-user OBO primitive, but its **`aud` is the receiving
+Authorization Server, not the Tool** — it is consumed by the app's AS, which then mints an ordinary access
+token for the Tool. It therefore satisfies "the Agent forwards a verifiable per-user identity the app's AS
+can verify," **not** "the Tool verifies it at the resource endpoint," and it defines **no** per-action
+primitive (deferring to RFC 9396). Hence **C1 is ADA-defined and tool-audience-bound**, and ID-JAG is an
+**optional upstream source** of verified user identity that an issuer MAY use to mint the C1 assertion.
+(Exact ID-JAG identifiers, for reference: token type `urn:ietf:params:oauth:token-type:id-jag`, header
+`typ: oauth-id-jag+jwt`, minted via RFC 8693 token-exchange, redeemed via RFC 7523 `jwt-bearer`.)
+
+## Per-transport placement
+
+- **stdio (local):** *(pending Open decision #4)* if applied, C1/C3 travel **only** in `params._meta` (OAuth
+  does not apply — MCP: stdio servers SHOULD obtain credentials from the environment). Anti-replay = `jti`
+  de-dup, for which the Tool MUST retain a replay cache for at least the maximum token `exp` and across process
+  recycling (note the tension with the statelessness guidance in Tool Spec §2.2.1); any server nonce is bound at
+  the DPoP/PoP layer (signed by the Agent at request time), **not** inside the pre-minted identity JWT. **[OPEN
+  DECISION]** whether ADA identity/consent is REQUIRED over stdio at all, given Tool Spec §1.1.1 treats local
+  transport as "authorized parent process."
+- **Streamable HTTP (remote):** the SAME `params._meta` carrier is normative *(pending Open decision #1)*;
+  **additionally** the Tool acts as an OAuth 2.1 Resource Server — advertising its audience via RFC 9728
+  protected-resource metadata, requiring RFC 8707 resource-indicator audience binding, and optionally validating
+  DPoP. (PKCE/S256 applies to the Agent↔authorization-server code flow, not to the Resource Server.) The header
+  path is an HTTP-only optimization and cannot be the sole mechanism.
+
+Both transports MUST use identical **JCS (RFC 8785)** canonicalization so Agent and Tool compute the same
+per-action binding.
+
+## Open WG decisions
+
+1. **C1 model** — ADA tool-audience-bound JWT (this draft) vs. deferring identity to the receiving AS's
+   downstream token.
+2. **Per-action binding** — RFC 9396 `authorization_details` vs. `aph` hash vs. allow both.
+3. **Proof-of-possession** — DPoP/`cnf` as MUST / SHOULD / MAY.
+4. **stdio scope** — does ADA identity/consent apply over stdio, or does local trust rest on the parent process?
+5. **Delegation chains & headless agents** — multi-tool `act` chains (ID-JAG-04 gives `act` no normative
+   processing) and public/headless agents (ID-JAG is confidential-clients-SHOULD).
+6. **Claim namespacing** — reuse registered claims / `authorization_details` vs. mint ADA-private claims
+   (`aph`, `corr_id`); register any new claims with IANA.
+
+## Pre-normative verification tasks
+
+- [ ] Re-check `_meta` end-to-end preservation in the MCP 2025-11-25 **transports** and **lifecycle** pages
+      (base protocol is silent); if unguaranteed, keep the ADA forwarding requirement above.
+- [ ] Examine the external `modelcontextprotocol/ext-auth` extensions repo (and any SEP, e.g. SEP-835) for a
+      per-user identity/consent extension that could overlap or supersede this `_meta` approach.
+- [ ] Confirm the `org.appdefensealliance/identity` and `.../consent` sub-keys are not reserved in
+      `schema/2025-11-25/schema.ts`, and confirm `CallToolRequest` `additionalProperties` behaviour.
+- [ ] Confirm ID-JAG remains at draft-04 (pin) and track for RFC/claim changes.
+
+## Non-normative example (straw-man, C1 over stdio)
+
+```json
+{
+  "jsonrpc": "2.0", "id": 42, "method": "tools/call",
+  "params": {
+    "name": "transfer_funds",
+    "arguments": { "amount": 500, "to": "acct_998" },
+    "_meta": {
+      "org.appdefensealliance/identity": "eyJ0eXAiOiJhcHBsaWNhdGlvbi9hZGEtaWRlbnRpdHkrand0...<JWS>",
+      "org.appdefensealliance/consent":  "eyJ0eXAiOiJhcHBsaWNhdGlvbi9hZGEtY29uc2VudCtqd3Q...<JWS>"
+    }
+  }
+}
+```
+Decoded C1 payload (illustrative): `{ "iss":"https://idp.example", "sub":"user_123",
+"aud":"https://tool.example/mcp", "client_id":"agent_abc", "act":{"sub":"agent_abc"}, "iat":..., "nbf":..., "exp":...,
+"jti":"...", "authorization_details":[{"type":"ada_tool_action","actions":["transfer_funds"],
+"amount":500,"to":"acct_998"}] }`.
+
+## References
+
+MCP 2025-11-25 (base / tools / authorization / elicitation) · Agent–Tool Interface Contract (C1, C3) ·
+AI Tool Specification §1.1.1, §1.2.2, §1.4, §2.1.1, §2.2.2 · ID-JAG draft-04 · OIDC Core 1.0 ·
+RFC 7515 / 7519 / 7638 / 7800 / 8693 / 8705 / 8707 / 9068 / 9396 / 9449 / 9728 / 8785 · CoSAI MCP Security §3.2.1–3.2.2 ·
+OWASP Top 10 for Agentic Applications 2026 ASI03 · AIUC-1 × OWASP crosswalk (Gap: signed per-action auth artifacts).
+
+## Licensing
+
+This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/).

--- a/AI Profile/AI Agent-Tool Identity and Consent Wire Format.md
+++ b/AI Profile/AI Agent-Tool Identity and Consent Wire Format.md
@@ -100,7 +100,7 @@ Tool emitting the optional `consent_required` signal — see *C3* below.
 
 ## Carrier: `_meta` canonical, `Authorization` header conformant on HTTP
 
-***Resolves Open Decision #1.*** The profile is **multi-modal**: one canonical placement that works
+***Resolves Open Decision 1.*** The profile is **multi-modal**: one canonical placement that works
 everywhere, plus a header path that is conformant on the transport where headers exist.
 
 - **`params._meta` is canonical.** The assertions travel in the `tools/call` request's **`params._meta`**
@@ -154,7 +154,7 @@ An ADA-defined, **tool-audience-bound** compact JWS/JWT.
 
 ### Per-action binding (Sensitive Actions)
 
-***Resolves Open Decision #2 — both forms permitted, RAR canonical.***
+***Resolves Open Decision 2 — both forms permitted, RAR canonical.***
 
 - **RFC 9396 `authorization_details` (canonical).** Structured (`type`/`actions`/`locations`/`identifier` +
   fields pinning the actual arguments, e.g. amount, destination); auditable; the Tool re-verifies each field.
@@ -169,7 +169,7 @@ MUST be rejected as ambiguous.
 
 ### Proof-of-possession
 
-***Resolves Open Decision #3 — `SHOULD`, at both tiers.***
+***Resolves Open Decision 3 — `SHOULD`, at both tiers.***
 
 `cnf`-based PoP (DPoP, RFC 9449, or mTLS, RFC 8705) is **RECOMMENDED (SHOULD)** and is **not** elevated to MUST
 for Sensitive Actions. Rationale: Agent Spec §6.1.3's freshness criteria are satisfied by the combination of a
@@ -270,7 +270,7 @@ primitive (deferring to RFC 9396). Hence **C1 is ADA-defined and tool-audience-b
   OAuth 2.1 Resource Server — advertising its audience via RFC 9728 protected-resource metadata, requiring
   RFC 8707 resource-indicator audience binding, and optionally validating DPoP. (PKCE/S256 applies to the
   Agent↔authorization-server code flow, not to the Resource Server.)
-- **stdio (local):** *(pending Open Decision #4)* if applied, C1/C3 travel **only** in `params._meta` (OAuth
+- **stdio (local):** *(pending Open Decision 4)* if applied, C1/C3 travel **only** in `params._meta` (OAuth
   does not apply — MCP: stdio servers SHOULD obtain credentials from the environment). Anti-replay = `jti`
   de-dup, for which the Tool MUST retain a replay cache for at least the maximum token `exp` and across process
   recycling (note the tension with the statelessness guidance in Tool Spec §2.2.1); any server nonce is bound at
@@ -282,9 +282,9 @@ per-action binding.
 ## Open WG decisions
 
 **Resolved in this revision** (proposed by the Chair following the industry-bar review; WG ratification still
-required): **#1 carrier** — multi-modal, `_meta` canonical + `Authorization` conformant on HTTP · **#2
-per-action binding** — RFC 9396 canonical, `aph` optional · **#3 proof-of-possession** — `SHOULD`, not MUST ·
-**#5 delegation chains & headless agents** — multi-hop `act` chains **deferred to a future revision**,
+required): **OD-1 carrier** — multi-modal, `_meta` canonical + `Authorization` conformant on HTTP · **OD-2
+per-action binding** — RFC 9396 canonical, `aph` optional · **OD-3 proof-of-possession** — `SHOULD`, not MUST ·
+**OD-5 delegation chains & headless agents** — multi-hop `act` chains **deferred to a future revision**,
 consistent with the agent-to-agent (A2A) / multi-agent composition deferral already recorded in the Agent
 Specification's scoping section · **trust anchor** — pinned allowlist bootstrapped from existing OAuth metadata.
 

--- a/AI Profile/AI Agent-Tool Identity and Consent Wire Format.md
+++ b/AI Profile/AI Agent-Tool Identity and Consent Wire Format.md
@@ -8,12 +8,20 @@
 > today; it gives the **ADA Malicious Reference Tool/Agent (MRT/MRA)** a concrete artifact to exercise; and
 > it is the candidate text for elevation to mandatory in a future revision **once ecosystem support exists**.
 >
-> **Why optional.** ADA's mandatory bar is deliberately set at what the most responsible, widely adopted
-> implementations can meet today — enough to keep irresponsible implementations out, not so far ahead that
-> conformance is unattainable. Agent-minted, per-request signed identity assertions verified at the Tool are
-> **not shipped by any tier-1 MCP provider** as of this revision, so requiring them would set an
-> unattainable bar. The mandatory requirements live in the AI Agent Specification (§2.4.1, §6.1.x); this
-> profile is the optional tier above them — see *Relationship to the mandatory baseline*.
+> **Why optional — the calibration test.** The market contains a wide diversity of agent↔tool approaches,
+> some of them manifestly insecure. ADA has **no obligation to accommodate those**, and this profile is
+> deliberately ahead of them. The bar is instead calibrated against a narrower reference class: **the
+> leading implementations from providers that are taking due care with security *and* that facilitate
+> consequential actions through their supported MCP tools.** Measured against *that* group, it would be a
+> failure of the standard if essentially **no one** clears the mandatory bar — a requirement nothing on the
+> market satisfies does not raise the security floor; it makes certification unattainable and invites the
+> requirement to be waived.
+>
+> Agent-minted, per-request signed identity assertions verified at the Tool — and especially per-action
+> cryptographic parameter binding — are not shipped **even within that reference class** as of this
+> revision. Mandating them would fail the test above, so they are specified here as an optional tier. The
+> mandatory requirements live in the AI Agent Specification (§2.4.1, §6.1.x); this profile sits above them —
+> see *Relationship to the mandatory baseline*.
 >
 > Open Decisions **1, 2, 3 and 5** and the **trust-anchor** question are **resolved** in this revision;
 > **Open Decisions 4 (stdio) and 6 (claim namespacing)** remain open. The **Pre-Normative Verification**
@@ -36,15 +44,16 @@ isolation can verify identity/consent from any conformant Agent.
 
 ## Relationship to the mandatory baseline
 
-ADA's **mandatory** agent↔tool security bar is set in the AI Agent Specification and is calibrated to what
-responsible, widely adopted implementations can meet today:
+ADA's **mandatory** agent↔tool security bar is set in the AI Agent Specification and is calibrated against
+the reference class described above — the leading implementations from providers taking due care with
+security that facilitate consequential actions through their supported MCP tools:
 
 | Layer | Where it lives | Status |
 |-------|----------------|--------|
 | Transport authentication (OAuth 2.1 / mTLS / rotated keys), PKCE, redirect-URI + state validation | Agent Spec §6.1.1, §6.1.4, §6.1.5 | **Mandatory** — universally implemented |
 | A user-scoped, audience-bound credential per tool call; no bare plain-text identifiers; no cross-user reuse; no token passthrough | Agent Spec §6.1.2, §2.4.1; Tool Spec §1.2.3 | **Mandatory** — achievable with standard OAuth 2.1 today |
 | Human-in-the-loop consent gate for Sensitive Actions, with shown-vs-executed fidelity | Agent Spec §2.2.2 | **Mandatory** — behavioural, no cryptographic artifact required |
-| **Agent-minted, per-request signed identity assertion verified by the Tool; per-action cryptographic binding; signed consent receipt** | **This profile (D1)** | **OPTIONAL** — not shipped by tier-1 providers; reference upgrade path |
+| **Agent-minted, per-request signed identity assertion verified by the Tool; per-action cryptographic binding; signed consent receipt** | **This profile (D1)** | **OPTIONAL** — not shipped even within the reference class; upgrade path |
 
 The dividing line is deliberate: the mandatory tier requires *behaviours and properties* that keep
 irresponsible implementations out — ambient or shared credentials, plain-text user IDs, forwarded tokens,
@@ -166,9 +175,9 @@ MUST be rejected as ambiguous.
 for Sensitive Actions. Rationale: Agent Spec §6.1.3's freshness criteria are satisfied by the combination of a
 short-lived assertion, a Tool-enforced `jti` replay cache, and TLS — so within the lab-testable scope of this
 profile PoP adds defense in depth rather than a distinct testable property. PoP also has effectively no
-production adoption across tier-1 MCP providers today, and a MUST would make the profile unimplementable rather
-than merely demanding. Deployments handling irreversible or high-value actions are strongly encouraged to
-enable it, and a future revision may elevate it once ecosystem support exists.
+production adoption even within the reference class today, and a MUST would make the profile unimplementable
+rather than merely demanding. Deployments handling irreversible or high-value actions are strongly encouraged
+to enable it, and a future revision may elevate it once ecosystem support exists.
 
 ## C3 — Consent Assertion (Sensitive Actions; fills Tool Spec §2.1.1)
 

--- a/AI Profile/AI Agent-Tool Identity and Consent Wire Format.md
+++ b/AI Profile/AI Agent-Tool Identity and Consent Wire Format.md
@@ -1,9 +1,24 @@
 # AI Agent–Tool Identity & Consent Wire Format
 
-> **Status: DRAFT / RFC — for Working Group feedback.** This document is a design proposal, not
-> ratified normative text. Sections marked **[OPEN DECISION]** require a WG determination, and the
-> **Pre-Normative Verification** checklist must be cleared before any requirement here becomes binding.
-> It is published together with issue **#379** to solicit feedback.
+> **Status: OPTIONAL conformance profile — not required for ADA certification.**
+>
+> An Agent **MAY** implement this profile. Doing so is **not** a condition of certification in this
+> revision, and an Agent that does not implement it is **not** non-conformant. The profile exists for three
+> reasons: it is the **reference upgrade path** for deployments that want verifiable agent↔tool identity
+> today; it gives the **ADA Malicious Reference Tool/Agent (MRT/MRA)** a concrete artifact to exercise; and
+> it is the candidate text for elevation to mandatory in a future revision **once ecosystem support exists**.
+>
+> **Why optional.** ADA's mandatory bar is deliberately set at what the most responsible, widely adopted
+> implementations can meet today — enough to keep irresponsible implementations out, not so far ahead that
+> conformance is unattainable. Agent-minted, per-request signed identity assertions verified at the Tool are
+> **not shipped by any tier-1 MCP provider** as of this revision, so requiring them would set an
+> unattainable bar. The mandatory requirements live in the AI Agent Specification (§2.4.1, §6.1.x); this
+> profile is the optional tier above them — see *Relationship to the mandatory baseline*.
+>
+> Open Decisions **1, 2, 3 and 5** and the **trust-anchor** question are **resolved** in this revision;
+> **Open Decisions 4 (stdio) and 6 (claim namespacing)** remain open. The **Pre-Normative Verification**
+> checklist must be cleared before any part of this profile is elevated to mandatory. Published with issue
+> **#379**.
 
 ## Purpose
 
@@ -19,6 +34,47 @@ This profile defines that assertion format ("**D1**") so that the ADA Malicious 
 Malicious Reference Agent (MRA) have a concrete artifact to exercise, and so that a Tool certified in
 isolation can verify identity/consent from any conformant Agent.
 
+## Relationship to the mandatory baseline
+
+ADA's **mandatory** agent↔tool security bar is set in the AI Agent Specification and is calibrated to what
+responsible, widely adopted implementations can meet today:
+
+| Layer | Where it lives | Status |
+|-------|----------------|--------|
+| Transport authentication (OAuth 2.1 / mTLS / rotated keys), PKCE, redirect-URI + state validation | Agent Spec §6.1.1, §6.1.4, §6.1.5 | **Mandatory** — universally implemented |
+| A user-scoped, audience-bound credential per tool call; no bare plain-text identifiers; no cross-user reuse; no token passthrough | Agent Spec §6.1.2, §2.4.1; Tool Spec §1.2.3 | **Mandatory** — achievable with standard OAuth 2.1 today |
+| Human-in-the-loop consent gate for Sensitive Actions, with shown-vs-executed fidelity | Agent Spec §2.2.2 | **Mandatory** — behavioural, no cryptographic artifact required |
+| **Agent-minted, per-request signed identity assertion verified by the Tool; per-action cryptographic binding; signed consent receipt** | **This profile (D1)** | **OPTIONAL** — not shipped by tier-1 providers; reference upgrade path |
+
+The dividing line is deliberate: the mandatory tier requires *behaviours and properties* that keep
+irresponsible implementations out — ambient or shared credentials, plain-text user IDs, forwarded tokens,
+cross-user contamination, ungated destructive actions. This optional profile adds the *cryptographic
+artifact* that makes those properties independently verifiable by the Tool. An Agent that meets the
+mandatory tier is conformant; an Agent that also implements D1 is verifiably stronger.
+
+## Conformance tiers *(within this optional profile)*
+
+An Agent that elects to implement D1 implements it in **two tiers**, mirroring the Agent Specification's own
+distinction between routine tool calls and Sensitive Actions:
+
+| Tier | Applies to | Artifact | Verifies |
+|------|-----------|----------|----------|
+| **Baseline** | Every tool request | C1 identity assertion (signed JWT, tool-audience-bound). **No** per-action parameter binding. | Tool-side verification of the user context that Agent Spec §6.1.2 requires the Agent to propagate |
+| **Sensitive Action** | Actions the Agent classifies as Sensitive | Baseline **+** per-action binding **+** C3 consent assertion carrying `corr_id` | Tool-side verification of the consent binding that Agent Spec §2.2.2 requires the Agent to enforce |
+
+A routine `search_docs` call therefore needs only a validated, audience-bound JWT. A `transfer_funds` call
+needs the full per-action binding and a consent receipt. Tiering keeps the entry cost low for ordinary tool
+traffic while reserving the expensive guarantees for the actions that warrant them.
+
+An Agent implementing D1 **partially** — Baseline only, without the Sensitive-Action tier — is a valid
+deployment choice and still satisfies the mandatory baseline, but MUST NOT claim D1 conformance for
+Sensitive Actions.
+
+**Classification is the Agent's.** Which operations are Sensitive Actions is determined by the Agent on its
+own criteria (irreversible; transfers value or money; mutates or shares user data beyond the current task;
+grants or expands access), per the Interface Contract and Agent Spec §2.2. It does **not** depend on the
+Tool emitting the optional `consent_required` signal — see *C3* below.
+
 ## Relationship to MCP and existing standards
 
 - **Target revision: MCP 2025-11-25.** MCP has **no native message-signing/integrity mechanism** and (as of
@@ -33,12 +89,23 @@ isolation can verify identity/consent from any conformant Agent.
   resource-server behaviour on HTTP), RFC 9396 (Rich Authorization Requests, per-action binding),
   RFC 9449 (DPoP), RFC 7638 (JWK thumbprint), RFC 8785 (JCS canonicalization), and RFC 7515/7519 (JWS/JWT).
 
-## Carrier: `params._meta`
+## Carrier: `_meta` canonical, `Authorization` header conformant on HTTP
 
-- The assertions travel in the `tools/call` request's **`params._meta`** object. `_meta` is MCP's reserved
-  extension point and rides in the JSON-RPC message body, so it is carried **identically over stdio and
-  Streamable HTTP** — the only transport-agnostic placement. (OAuth/`Authorization` headers exist on
-  Streamable HTTP only; stdio has no headers.)
+***Resolves Open Decision #1.*** The profile is **multi-modal**: one canonical placement that works
+everywhere, plus a header path that is conformant on the transport where headers exist.
+
+- **`params._meta` is canonical.** The assertions travel in the `tools/call` request's **`params._meta`**
+  object. `_meta` is MCP's reserved extension point and rides in the JSON-RPC message body, so it is carried
+  **identically over stdio and Streamable HTTP** — the only transport-agnostic placement.
+- **`Authorization: Bearer <C1 JWT>` is equally conformant for Streamable HTTP.** Agent Spec §6.1.2's own
+  test procedure inspects "the intercepted request's payload, **metadata, or headers**," and its verification
+  criterion accepts the token attached "to the **metadata or headers** of every downstream tool invocation."
+  A `_meta`-only rule would therefore be *narrower than the specification it implements*. On HTTP the header
+  is the natural carrier, is already intercepted by the §6.1.1/§6.1.2 test procedures, and sidesteps the
+  `_meta` proxy-preservation concern entirely for the security-critical remote transport. The **C3 consent
+  assertion**, having no standard header, travels in `_meta` on both transports.
+- **Precedence.** If both are present, the Tool MUST verify both and MUST reject the request when they are
+  not identical assertions. A Tool MUST accept at least the canonical `_meta` placement.
 - **Keys (reverse-DNS, per MCP's SHOULD):** `org.appdefensealliance/identity` (C1) and
   `org.appdefensealliance/consent` (C3). Prefixes whose second label is `mcp`/`modelcontextprotocol` are
   reserved for MCP; `org.appdefensealliance` is not. *(Verification task: confirm these sub-keys are not
@@ -46,43 +113,64 @@ isolation can verify identity/consent from any conformant Agent.
 - **Not in `arguments`.** The assertion MUST NOT be placed in `params.arguments`: it would collide with the
   tool's `inputSchema`, be visible to the model, and risk being stripped by `additionalProperties:false`.
 - **Preservation requirement (ADA-defined).** MCP's base spec is **silent** on whether `_meta` is preserved
-  end-to-end through servers/gateways/proxies. This profile therefore REQUIRES that intermediaries forward
-  the `org.appdefensealliance/*` `_meta` keys **unchanged**. Because C1/C3 are **compact JWS/JWT (embedded
-  payload)**, tampering with the **assertion itself** is cryptographically detectable at the verifier. Note the
-  signature covers only the assertion's claims: the `tools/call` `name`/`arguments` are integrity-bound **only**
-  via the per-action binding, which is REQUIRED for Sensitive Actions — so for **non-Sensitive** calls the
-  arguments are **not** integrity-protected against a malicious intermediary (accept this residual risk, or
-  extend per-action binding to all calls — **[OPEN DECISION]**). The remaining risk is *silent stripping*
-  (availability), in which case the Tool MUST **fail closed**. *(Verification task: re-check the MCP
-  2025-11-25 transports/lifecycle pages for any preservation guarantee.)*
+  end-to-end through servers/gateways/proxies. Where `_meta` is the carrier, this profile REQUIRES that
+  intermediaries forward the `org.appdefensealliance/*` keys **unchanged**. Because C1/C3 are **compact
+  JWS/JWT (embedded payload)**, tampering with the **assertion itself** is cryptographically detectable at the
+  verifier. Note the signature covers only the assertion's claims: the `tools/call` `name`/`arguments` are
+  integrity-bound **only** via the per-action binding, which is REQUIRED for Sensitive Actions — so for
+  **Baseline-tier** calls the arguments are **not** integrity-protected against a malicious intermediary. This
+  residual risk is **accepted at the Baseline tier**: it is the same exposure any bearer-token API has, and the
+  actions that would make argument tampering consequential are precisely those that require the Sensitive-Action
+  tier. The remaining risk is *silent stripping* (availability), in which case the Tool MUST **fail closed**.
+  *(Verification task: re-check the MCP 2025-11-25 transports/lifecycle pages for any preservation guarantee.)*
 
-## C1 — Identity Assertion (baseline, every Tool request)
+## C1 — Identity Assertion (Baseline tier, every Tool request)
 
 An ADA-defined, **tool-audience-bound** compact JWS/JWT.
 
-| Field | Value / meaning |
-|-------|-----------------|
-| `typ` (header) | `application/ada-identity+jwt` (distinct `typ` prevents cross-use) |
-| `alg` (header) | asymmetric allowlist only (e.g. `ES256`/`EdDSA`); `none` and `HS*` MUST be rejected |
-| `kid` (header) | key id into the issuer's JWKS/trust bundle |
-| `iss` | trusted IdP/issuer that authenticated the end user (on the Tool's pinned allowlist) |
-| `sub` | stable end-user identifier (used as `{JWT.sub}` for downstream scoping per Tool Spec §2.2.2) |
-| `aud` | **the specific target Tool / canonical MCP-server identifier** (defeats confused-deputy/redirection) |
-| `client_id` | the calling Agent |
-| `act` | `{ "sub": <agent/workload id> }` — RFC 8693 delegation (subject = user, actor = agent; no token passthrough) |
-| `iat`, `nbf`, `exp` | short lifetime (minutes); per-request freshness |
-| `jti` | unique id; Tool de-dupes for replay defense (pairs with Tool Spec §1.4) |
-| `cnf` | *(optional, RFC 7800)* PoP binding: `jkt` (JWK thumbprint, RFC 7638) for **DPoP** (RFC 9449), or `x5t#S256` for **mTLS** (RFC 8705) |
-| **per-action binding** | **REQUIRED for Sensitive Actions** — see below |
+| Field | Tier | Value / meaning |
+|-------|------|-----------------|
+| `typ` (header) | Baseline | `application/ada-identity+jwt` (distinct `typ` prevents cross-use) |
+| `alg` (header) | Baseline | asymmetric allowlist only (e.g. `ES256`/`EdDSA`); `none` and `HS*` MUST be rejected |
+| `kid` (header) | Baseline | key id into the issuer's JWKS/trust bundle |
+| `iss` | Baseline | trusted IdP/issuer that authenticated the end user (on the Tool's pinned allowlist) |
+| `sub` | Baseline | stable end-user identifier (used as `{JWT.sub}` for downstream scoping per Tool Spec §2.2.2) |
+| `aud` | Baseline | **the specific target Tool / canonical MCP-server identifier** (defeats confused-deputy/redirection) |
+| `client_id` | Baseline | the calling Agent |
+| `act` | Baseline | `{ "sub": <agent/workload id> }` — RFC 8693 delegation (subject = user, actor = agent). This is the wire-level expression of **no token passthrough**, the rule now normative in Tool Spec §1.2.3. |
+| `iat`, `nbf`, `exp` | Baseline | short lifetime (minutes); per-request freshness |
+| `jti` | Baseline | unique id; Tool de-dupes for replay defense (pairs with Tool Spec §1.4 and Agent Spec §6.1.3) |
+| `cnf` | **SHOULD** | *(RFC 7800)* PoP binding: `jkt` (JWK thumbprint, RFC 7638) for **DPoP** (RFC 9449), or `x5t#S256` for **mTLS** (RFC 8705) — see *Proof-of-possession* |
+| **per-action binding** | **Sensitive Actions — REQUIRED** | see below |
 
-**Per-action binding** (for Sensitive Actions), one of **[OPEN DECISION]**:
-- **RFC 9396 `authorization_details`** — structured (`type`/`actions`/`locations`/`identifier` + fields
-  pinning the actual arguments, e.g. amount, destination); auditable; Tool re-verifies each field. *(Favoured
-  for alignment with ID-JAG's RAR endorsement.)*
-- **`aph` (action-parameter hash)** — `base64url(SHA-256(JCS(bind_object)))` where
-  `bind_object = { tool: params.name, args: params.arguments, aud }` (`jti` is already a signed claim and is **not** folded into `aph`); opaque, simple (DPoP-`ath` style).
+### Per-action binding (Sensitive Actions)
 
-## C3 — Consent Assertion (deferred tier; fills Tool Spec §2.1.1)
+***Resolves Open Decision #2 — both forms permitted, RAR canonical.***
+
+- **RFC 9396 `authorization_details` (canonical).** Structured (`type`/`actions`/`locations`/`identifier` +
+  fields pinning the actual arguments, e.g. amount, destination); auditable; the Tool re-verifies each field.
+  Favoured for alignment with ID-JAG's RAR endorsement and because an auditor can read the binding.
+- **`aph` (action-parameter hash) — OPTIONAL lightweight alternative.**
+  `base64url(SHA-256(JCS(bind_object)))` where `bind_object = { tool: params.name, args: params.arguments, aud }`
+  (`jti` is already a signed claim and is **not** folded into `aph`); opaque, simple (DPoP-`ath` style). Suitable
+  where arguments are large or the Agent cannot enumerate them structurally.
+
+A Tool MUST support `authorization_details` and MAY additionally support `aph`. An assertion carrying both
+MUST be rejected as ambiguous.
+
+### Proof-of-possession
+
+***Resolves Open Decision #3 — `SHOULD`, at both tiers.***
+
+`cnf`-based PoP (DPoP, RFC 9449, or mTLS, RFC 8705) is **RECOMMENDED (SHOULD)** and is **not** elevated to MUST
+for Sensitive Actions. Rationale: Agent Spec §6.1.3's freshness criteria are satisfied by the combination of a
+short-lived assertion, a Tool-enforced `jti` replay cache, and TLS — so within the lab-testable scope of this
+profile PoP adds defense in depth rather than a distinct testable property. PoP also has effectively no
+production adoption across tier-1 MCP providers today, and a MUST would make the profile unimplementable rather
+than merely demanding. Deployments handling irreversible or high-value actions are strongly encouraged to
+enable it, and a future revision may elevate it once ecosystem support exists.
+
+## C3 — Consent Assertion (Sensitive Actions; fills Tool Spec §2.1.1)
 
 Same envelope, `typ = application/ada-consent+jwt`. Binds the four things C3 requires:
 
@@ -90,35 +178,70 @@ Same envelope, `typ = application/ada-consent+jwt`. Binds the four things C3 req
 |-------|---------|
 | `sub` | the SAME verified end user as C1 (consent tied to identity) |
 | `aud` + operation | the specific Tool + operation (consent bound to one action) |
-| per-action binding | `authorization_details` or `aph` — Tool recomputes and rejects on mismatch (defeats "consent to X, execute Y") |
-| `corr_id` | correlation ID for audit (satisfies the C3 Agent obligation to record) |
+| per-action binding | `authorization_details` (or `aph`) — Tool recomputes and rejects on mismatch (defeats "consent to X, execute Y") |
+| `corr_id` | correlation ID for audit (satisfies the C3 Agent obligation to record, and Agent Spec §2.2.2's correlation-ID criterion) |
 | `jti`, `nbf`, `exp`, optional `cnf.jkt` | anti-replay |
 | `act` | agent as actor (RFC 8693) |
 
+**The receipt is Agent-minted and does not depend on the Tool's `consent_required` signal.** The Agent
+classifies the action as Sensitive on its own criteria, obtains user consent, mints the C3 assertion, and the
+Tool verifies it. This keeps consent agent-side per Contract **C3** and removes the dependency identified in
+issue **#399** — where the Agent-side consent test was keyed to a Tool signal that the Tool Specification
+defines only as a MAY. Where a Tool *does* emit `consent_required`, the Agent MUST honour it; its absence MUST
+NOT prevent the Agent from gating an action it independently classifies as Sensitive.
+
 **Relationship to MCP elicitation:** elicitation is the interactive *moment-of-consent trigger* only; its
 response carries **no signature or identity binding** (client-provided identity is forgeable), so it is
-**not** an acceptable consent receipt. The verifiable artifact is this signed C3 JWT.
+**not** an acceptable consent receipt. The verifiable artifact is this signed C3 JWT. (Agent-side conformance
+to the elicitation protocol itself is tested separately by Agent Spec §2.2.3.)
 
-## Trust anchor / key distribution **[OPEN DECISION]**
+## Trust anchor / key distribution
 
-The Tool holds a **pinned issuer allowlist / trust bundle** (open `iss`-based discovery is forbidden).
-Verification key resolved by `kid`. Distribution options for WG choice:
-1. OIDC Discovery `jwks_uri` **constrained by the allowlist**;
-2. **SPIFFE** trust bundle + Federation (JWT-SVID for the agent/actor);
-3. an **ADA-run/endorsed registry or CA** (OWASP ANS-style PKI).
-Key rotation via `kid` + JWKS cache TTL with refresh-on-unknown-`kid` and an overlap window.
+***Resolved — pinned allowlist, bootstrapped from existing OAuth metadata.***
+
+The Tool holds a **pinned issuer allowlist / trust bundle**; open `iss`-based discovery is forbidden. The
+verification key is resolved by `kid` via the issuer's **OIDC Discovery `jwks_uri`, constrained by that
+allowlist** — a key is only ever fetched from an issuer already on the list.
+
+Bootstrapping reuses infrastructure the profile already assumes rather than introducing a parallel trust
+system: the Agent↔Tool relationship is pre-configured (the Agent maintains a tool registry with pinned
+identities, per the agent-side provenance control proposed in issue **#401**), and on HTTP the Tool already
+advertises itself via **RFC 9728** protected-resource metadata as part of the OAuth flow that Agent Spec
+§6.1.4/§6.1.5 require. Trust anchors are therefore established at configuration time, in the same step that
+pins the tool identity.
+
+Key rotation via `kid` + JWKS cache TTL with refresh-on-unknown-`kid` and an overlap window. **SPIFFE** trust
+bundles (JWT-SVID for the agent/actor) and an **ADA-run/endorsed registry or CA** (OWASP ANS-style PKI) remain
+permissible deployment substrates for the allowlist, but neither is required by this profile.
 
 ## Tool-side verification algorithm
 
 1. Reject if `alg` not on the asymmetric allowlist (`none`/`HS*` → fail).
 2. Resolve key by `kid`; **`iss` MUST be on the pinned allowlist**; verify signature.
-3. Validate `aud` == this Tool, `exp`/`nbf`, and `jti` not previously seen (replay).
-4. For a Sensitive Action: recompute the per-action binding — for `aph`, JCS-hash the full
-   `bind_object` (`{ tool: params.name, args: params.arguments, aud }`); for `authorization_details`, match each
-   field against the **actual** `params.name`/`params.arguments` — and reject on mismatch.
-5. For C3: additionally require a valid Consent Assertion bound to the same `sub` + operation + parameters.
+3. Validate `aud` == this Tool, `exp`/`nbf`, and `jti` not previously seen (replay). If both a header and a
+   `_meta` assertion are present, verify both and reject on any mismatch.
+4. **Baseline tier ends here.** For a Sensitive Action, additionally recompute the per-action binding — for
+   `authorization_details`, match each field against the **actual** `params.name`/`params.arguments`; for `aph`,
+   JCS-hash the full `bind_object` (`{ tool: params.name, args: params.arguments, aud }`) — and reject on mismatch.
+5. For a Sensitive Action: additionally require a valid C3 Consent Assertion bound to the same `sub` +
+   operation + parameters, carrying `corr_id`.
 6. Any failure → **hard-fail (`401`/`403`)**, fail closed. (MRA exercises forged/missing/mismatched/replayed
    assertions against these steps.)
+
+## Mapping to Agent Specification test procedures
+
+D1 is **one sufficient way — not the only way — to satisfy** the mandatory test procedures below. A lab
+assessing an Agent that implements D1 may accept these artifacts as evidence; an Agent that satisfies the
+same procedures by other conformant means (e.g. a standard OAuth 2.1 JWT access token scoped to the user
+and audience-bound to the Tool) is equally conformant. The Agent Specification therefore does **not**
+reference this profile normatively.
+
+| Agent Spec test | What it requires | Artifact D1 supplies (if implemented) |
+|-----------------|------------------|----------------------------------------|
+| §6.1.2 Cryptographic Validation of User Context | "user context is passed as a cryptographically signed token (e.g., a JWT)" in payload, metadata, or headers | **Baseline C1** assertion (either carrier) |
+| §2.4.1 Verifiable Identity Forwarding | a user-scoped, audience-bound credential per request; per-action binding is the optional tier | **Baseline C1**; **per-action binding** at the Sensitive tier |
+| §2.2.2 Human in the Loop | consent bound to the user identity and operation parameters, recorded with a correlation ID | **C3** assertion (`sub` + binding + `corr_id`) |
+| §6.1.3 Message Freshness | "unique nonce or accurate timestamp" per request | `jti` + short `exp`, with Tool-side replay cache |
 
 ## Relationship to ID-JAG (why it is upstream, not the wire artifact)
 
@@ -133,45 +256,72 @@ primitive (deferring to RFC 9396). Hence **C1 is ADA-defined and tool-audience-b
 
 ## Per-transport placement
 
-- **stdio (local):** *(pending Open decision #4)* if applied, C1/C3 travel **only** in `params._meta` (OAuth
+- **Streamable HTTP (remote):** C1 travels in **either** `params._meta` **or** the `Authorization` header
+  (both conformant — see *Carrier*); C3 travels in `params._meta`. **Additionally** the Tool acts as an
+  OAuth 2.1 Resource Server — advertising its audience via RFC 9728 protected-resource metadata, requiring
+  RFC 8707 resource-indicator audience binding, and optionally validating DPoP. (PKCE/S256 applies to the
+  Agent↔authorization-server code flow, not to the Resource Server.)
+- **stdio (local):** *(pending Open Decision #4)* if applied, C1/C3 travel **only** in `params._meta` (OAuth
   does not apply — MCP: stdio servers SHOULD obtain credentials from the environment). Anti-replay = `jti`
   de-dup, for which the Tool MUST retain a replay cache for at least the maximum token `exp` and across process
   recycling (note the tension with the statelessness guidance in Tool Spec §2.2.1); any server nonce is bound at
-  the DPoP/PoP layer (signed by the Agent at request time), **not** inside the pre-minted identity JWT. **[OPEN
-  DECISION]** whether ADA identity/consent is REQUIRED over stdio at all, given Tool Spec §1.1.1 treats local
-  transport as "authorized parent process."
-- **Streamable HTTP (remote):** the SAME `params._meta` carrier is normative *(pending Open decision #1)*;
-  **additionally** the Tool acts as an OAuth 2.1 Resource Server — advertising its audience via RFC 9728
-  protected-resource metadata, requiring RFC 8707 resource-indicator audience binding, and optionally validating
-  DPoP. (PKCE/S256 applies to the Agent↔authorization-server code flow, not to the Resource Server.) The header
-  path is an HTTP-only optimization and cannot be the sole mechanism.
+  the DPoP/PoP layer (signed by the Agent at request time), **not** inside the pre-minted identity JWT.
 
 Both transports MUST use identical **JCS (RFC 8785)** canonicalization so Agent and Tool compute the same
 per-action binding.
 
 ## Open WG decisions
 
-1. **C1 model** — ADA tool-audience-bound JWT (this draft) vs. deferring identity to the receiving AS's
-   downstream token.
-2. **Per-action binding** — RFC 9396 `authorization_details` vs. `aph` hash vs. allow both.
-3. **Proof-of-possession** — DPoP/`cnf` as MUST / SHOULD / MAY.
-4. **stdio scope** — does ADA identity/consent apply over stdio, or does local trust rest on the parent process?
-5. **Delegation chains & headless agents** — multi-tool `act` chains (ID-JAG-04 gives `act` no normative
-   processing) and public/headless agents (ID-JAG is confidential-clients-SHOULD).
+**Resolved in this revision** (proposed by the Chair following the industry-bar review; WG ratification still
+required): **#1 carrier** — multi-modal, `_meta` canonical + `Authorization` conformant on HTTP · **#2
+per-action binding** — RFC 9396 canonical, `aph` optional · **#3 proof-of-possession** — `SHOULD`, not MUST ·
+**#5 delegation chains & headless agents** — multi-hop `act` chains **deferred to a future revision**,
+consistent with the agent-to-agent (A2A) / multi-agent composition deferral already recorded in the Agent
+Specification's scoping section · **trust anchor** — pinned allowlist bootstrapped from existing OAuth metadata.
+
+**Still open:**
+
+4. **stdio scope** — does ADA identity/consent apply over stdio, or does local trust rest on the parent
+   process (Tool Spec §1.1.1's "authorized parent process")? **Blocked on issue #452:** §6.1.1 carries the
+   note *"This requirement only applies to agents which support remote tools,"* but **§6.1.2 (cryptographic
+   user context) and §6.1.3 (message freshness) carry no such note**, so as written they apply to *all*
+   agents — including stdio-only ones. This profile therefore **cannot** declare stdio out of scope without
+   contradicting §6.1.2. Resolve the Specification's applicability first, then settle this decision to match.
 6. **Claim namespacing** — reuse registered claims / `authorization_details` vs. mint ADA-private claims
    (`aph`, `corr_id`); register any new claims with IANA.
 
 ## Pre-normative verification tasks
 
 - [ ] Re-check `_meta` end-to-end preservation in the MCP 2025-11-25 **transports** and **lifecycle** pages
-      (base protocol is silent); if unguaranteed, keep the ADA forwarding requirement above.
+      (base protocol is silent). Now lower-severity for HTTP (the header carrier is conformant), but still
+      decisive for stdio and for C3 on both transports.
 - [ ] Examine the external `modelcontextprotocol/ext-auth` extensions repo (and any SEP, e.g. SEP-835) for a
       per-user identity/consent extension that could overlap or supersede this `_meta` approach.
 - [ ] Confirm the `org.appdefensealliance/identity` and `.../consent` sub-keys are not reserved in
       `schema/2025-11-25/schema.ts`, and confirm `CallToolRequest` `additionalProperties` behaviour.
 - [ ] Confirm ID-JAG remains at draft-04 (pin) and track for RFC/claim changes.
+- [ ] Confirm no conflict between the `Authorization: Bearer <C1>` carrier and a Tool's own OAuth 2.1
+      resource-server access token on Streamable HTTP; if a deployment needs both, specify which header
+      carries which (candidate: C1 in `Authorization`, tool access token via the established OAuth flow, or a
+      dedicated `ADA-Identity` header).
 
-## Non-normative example (straw-man, C1 over stdio)
+## Non-normative examples (straw-man)
+
+**Baseline tier** — routine call, C1 only, HTTP header carrier:
+
+```http
+POST /mcp HTTP/1.1
+Authorization: Bearer eyJ0eXAiOiJhcHBsaWNhdGlvbi9hZGEtaWRlbnRpdHkrand0...<JWS>
+Content-Type: application/json
+
+{ "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+  "params": { "name": "search_docs", "arguments": { "q": "retention policy" } } }
+```
+Decoded C1 payload (illustrative): `{ "iss":"https://idp.example", "sub":"user_123",
+"aud":"https://tool.example/mcp", "client_id":"agent_abc", "act":{"sub":"agent_abc"}, "iat":..., "nbf":...,
+"exp":..., "jti":"..." }` — no per-action binding at this tier.
+
+**Sensitive Action tier** — C1 with per-action binding + C3 consent receipt, `_meta` carrier (stdio):
 
 ```json
 {
@@ -186,17 +336,19 @@ per-action binding.
   }
 }
 ```
-Decoded C1 payload (illustrative): `{ "iss":"https://idp.example", "sub":"user_123",
-"aud":"https://tool.example/mcp", "client_id":"agent_abc", "act":{"sub":"agent_abc"}, "iat":..., "nbf":..., "exp":...,
-"jti":"...", "authorization_details":[{"type":"ada_tool_action","actions":["transfer_funds"],
-"amount":500,"to":"acct_998"}] }`.
+Decoded C1 payload (illustrative): as above, plus
+`"authorization_details":[{"type":"ada_tool_action","actions":["transfer_funds"],"amount":500,"to":"acct_998"}]`.
+Decoded C3 payload (illustrative): same `sub`/`aud`, the same `authorization_details`, plus
+`"corr_id":"01JD…"`.
 
 ## References
 
 MCP 2025-11-25 (base / tools / authorization / elicitation) · Agent–Tool Interface Contract (C1, C3) ·
-AI Tool Specification §1.1.1, §1.2.2, §1.4, §2.1.1, §2.2.2 · ID-JAG draft-04 · OIDC Core 1.0 ·
-RFC 7515 / 7519 / 7638 / 7800 / 8693 / 8705 / 8707 / 9068 / 9396 / 9449 / 9728 / 8785 · CoSAI MCP Security §3.2.1–3.2.2 ·
-OWASP Top 10 for Agentic Applications 2026 ASI03 · AIUC-1 × OWASP crosswalk (Gap: signed per-action auth artifacts).
+AI Agent Specification §2.2.2, §2.2.3, §2.4.1, §6.1.1–§6.1.5 ·
+AI Tool Specification §1.1.1, §1.2.2, §1.2.3, §1.4, §2.1.1, §2.2.2 · ID-JAG draft-04 · OIDC Core 1.0 ·
+RFC 7515 / 7519 / 7523 / 7638 / 7800 / 8693 / 8705 / 8707 / 9068 / 9396 / 9449 / 9728 / 8785 ·
+CoSAI MCP Security §3.2.1–3.2.2 · OWASP Top 10 for Agentic Applications 2026 ASI03 ·
+AIUC-1 × OWASP crosswalk (Gap: signed per-action auth artifacts).
 
 ## Licensing
 


### PR DESCRIPTION
## 🔗 Linked Issue
Fixes #379

## 📖 Summary

Defines **D1**, the Agent↔Tool identity & consent wire format, and — following the industry-bar adversarial review — **repositions it as an OPTIONAL conformance profile** rather than mandatory normative text.

### Why optional

This is **not** "the ADA spec cannot be ahead of the industry." The market contains a wide diversity of agent↔tool approaches, some **manifestly insecure** — ADA has no obligation to accommodate those, and this specification is deliberately ahead of them and should keep them out.

The calibration reference class is narrower: **the leading implementations from providers taking due care with security *and* facilitating consequential actions through their supported MCP tools.** Measured against *that* group, it is a failure of the standard if essentially **no one** clears the bar — a requirement nothing satisfies does not raise the security floor; it makes certification unattainable and invites the requirement to be waived.

Agent-minted, per-request signed identity assertions verified at the Tool — and per-action cryptographic parameter binding — are **not shipped even within that reference class** today, so mandating them would fail that test.

So D1 is now: an Agent **MAY** implement it; it is **not** a condition of certification; it is the **reference upgrade path**, the **MRT/MRA test target**, and the candidate text for elevation to mandatory in a future revision once ecosystem support exists.

### Where the line sits

| Layer | Where | Status |
|---|---|---|
| Transport auth, PKCE, redirect/state | Agent Spec §6.1.1/§6.1.4/§6.1.5 | Mandatory — universal |
| User-scoped, audience-bound credential; no plaintext IDs; no cross-user reuse; no token passthrough | Agent Spec §6.1.2/§2.4.1, Tool Spec §1.2.3 | Mandatory — achievable with standard OAuth 2.1 |
| Consent gate for Sensitive Actions + shown-vs-executed fidelity | Agent Spec §2.2.2 | Mandatory — behavioural |
| **Signed per-request assertion, per-action binding, signed consent receipt** | **D1 (this PR)** | **Optional** |

The mandatory tier requires the *properties* that exclude bad implementations; D1 adds the *cryptographic artifact* that makes them Tool-verifiable.

## ✅ Open Decisions resolved

- **OD-1 Carrier — multi-modal.** `params._meta` canonical; **`Authorization: Bearer` equally conformant on Streamable HTTP.** §6.1.2's own test procedure inspects *"payload, metadata, **or headers**"*, so the previous `_meta`-only rule was **narrower than the requirement it implements**. The header path also eliminates the `_meta` proxy-preservation risk on the security-critical remote transport.
- **OD-2 Per-action binding.** RFC 9396 `authorization_details` canonical; `aph` hash permitted as an optional lightweight alternative.
- **OD-3 Proof-of-possession — `SHOULD`, not MUST** (at both tiers). `jti` + short `exp` + TLS already satisfy §6.1.3's freshness criteria; DPoP has effectively no production adoption.
- **OD-5 Delegation chains / headless agents — deferred**, consistent with the A2A out-of-scope disposition already merged into the Agent Spec scoping section.
- **Trust anchor.** Pinned issuer allowlist with JWKS resolution constrained by it, bootstrapped at configuration time from the tool registry (#401) and RFC 9728 metadata — no parallel trust system.

## ⏸️ Still open

- **OD-4 stdio scope — blocked on #452.** §6.1.1 is remote-only but §6.1.2/§6.1.3 carry no applicability note, so D1 **cannot** declare stdio out of scope without contradicting §6.1.2. (The review's recommendation to exempt stdio was based on the incorrect premise that §6.1.1–§6.1.5 are all remote-scoped; that note appears exactly once, under §6.1.1.)
- **OD-6 Claim namespacing** — IANA registration for any ADA-private claims.

## 🔁 Also resolves a cross-issue dependency

C3 is now explicitly **Agent-minted** and independent of the Tool's optional `consent_required` signal — removing the dependency identified in **#399** (and aligning with PR #438).

## 🔗 Related

- **#451** — re-baseline §2.4.1 to an industry-achievable bar (the mandatory-tier counterpart to this PR)
- **#452** — §6.1 applicability inconsistency (blocks Open Decision 4)

## 📋 Requirement Verification
- [x] The proposed requirement text matches the approved Issue.
- [x] All automated tests/checks pass on the `develop` branch. (New standalone document; not covered by the Spec↔Guide lint.)

## ⚖️ Governance & Consensus
- [ ] **Consensus Reached:** The Working Group has reached a rough consensus on this change.
- [ ] **Voting:** If required, the formal vote has passed (Link to vote results: [URL]).
- [ ] **Reviewers:** At least two members of the Working Group have signed off on this PR.


