### PR TITLE
Exclude user-initiated exports of sensitive data from 1.1.1.1 (Android) and 2.1.1.1 (iOS)

### DIFF
--- a/MASA/MASA Test Guide.md
+++ b/MASA/MASA Test Guide.md
@@ -163,6 +163,18 @@ _AL2_
 1. Output of the analysis shows that the app does not write and store unencrypted and sensitive data in external storage.
 2. Or, if sensitive data is being written to external storage, verify that the crypto implementation meets the [baseline crypto requirements](#22-crypto).
 
+_Additional Context_
+
+The following are out of scope:
+
+* Files containing sensitive data that are created through a user-initiated export, backup, or data-portability flow, provided all of the following conditions are met:
+    * The export is triggered by an explicit user action for each export (e.g. an "Export", "Download", or "Back up" control). Exports performed automatically, by default, on a recurring schedule, or as a side effect of normal app operation do not qualify — a one-time opt-in to a scheduled or recurring backup does not constitute an explicit user action for each export.
+    * The user selects or confirms the destination through a platform-provided mechanism (e.g. the Storage Access Framework document picker or the system share sheet).
+    * The export serves a user-directed portability, backup, or interoperability purpose, typically in a standard or commonly used interchange format (e.g. CSV, HTML, GPX/FIT, ICS, vCard, OFX, FHIR/CDA), where mandatory app-controlled encryption would defeat that purpose.
+    * The app clearly informs the user, before or at the time of export, that the export will produce an unprotected file containing sensitive data.
+
+Sensitive data written to external storage in the course of normal app operation (e.g. caches, logs, autosaved copies, temporary files created for sharing) remains in scope regardless of any export functionality the app offers. Apps should additionally require re-authentication (e.g. device credential or biometric) before exporting highly sensitive data such as credentials.
+
 ---
 
 ### 1.1.2 [The app prevents leakage of sensitive data](https://mas.owasp.org/MASVS/controls/MASVS-STORAGE-2/)
@@ -1400,6 +1412,18 @@ _AL2_
 
 1. Output of the analysis shows that the app does not write and store unencrypted and sensitive data in external storage.
 2. If sensitive data is being written to external storage, verify that the crypto implementation meets the [baseline crypto requirements](#heading=h.qck736ryyi5).
+
+_Additional Context_
+
+The following are out of scope:
+
+* Files containing sensitive data that are created through a user-initiated export, backup, or data-portability flow, provided all of the following conditions are met:
+    * The export is triggered by an explicit user action for each export (e.g. an "Export", "Download", or "Back up" control). Exports performed automatically, by default, on a recurring schedule, or as a side effect of normal app operation do not qualify — a one-time opt-in to a scheduled or recurring backup does not constitute an explicit user action for each export.
+    * The user selects or confirms the destination through a platform-provided mechanism (e.g. the system document picker (`UIDocumentPickerViewController`) or share sheet).
+    * The export serves a user-directed portability, backup, or interoperability purpose, typically in a standard or commonly used interchange format (e.g. CSV, HTML, GPX/FIT, ICS, vCard, OFX, FHIR/CDA), where mandatory app-controlled encryption would defeat that purpose.
+    * The app clearly informs the user, before or at the time of export, that the export will produce an unprotected file containing sensitive data.
+
+Use of `UIDocumentPickerViewController` solely to implement a qualifying export flow is not, by itself, considered insecure storage of sensitive data in external storage under this requirement. Sensitive data written to external storage in the course of normal app operation (e.g. caches, logs, autosaved copies, temporary files created for sharing) remains in scope regardless of any export functionality the app offers. Apps should additionally require re-authentication (e.g. device credential or biometric) before exporting highly sensitive data such as credentials.
 
 ---
 


### PR DESCRIPTION
Closes #397 

## Summary

Adds an `_Additional Context_` out-of-scope block to **1.1.1.1** and **2.1.1.1**, mirroring the existing construct in 1.4.1.1 / 2.4.1.1. Files produced by a **user-initiated export, backup, or data-portability flow** are excluded from the secure-external-storage requirement when four cumulative conditions hold: (1) explicit user action per export, (2) destination chosen via a platform-provided picker or share sheet, (3) a portability/interoperability purpose in a standard interchange format where mandatory encryption would defeat the feature (e.g., credential CSV export, bookmarks HTML, GPX/FIT/FHIR health data, OFX/QIF finance exports), and (4) a clear warning to the user that the export will produce an unprotected file.

Everything the app writes to external storage during normal operation — caches, logs, autosaves, temp share files, silent backups — remains fully in scope. Recurring or scheduled backups are explicitly non-qualifying, even when the user opted in once. Re-authentication before credential-class exports remains should-level guidance.

Rationale, worked examples are in the linked issue.

## Requirement Verification

The modified requirement remains testable at both assurance levels:

- **AL1:** Developer evidence (Manifest / `UIDocumentPickerViewController` screenshots) continues to identify all external-storage writes. For each, the lab determines from the evidence whether it is a qualifying export flow (explicit user control, platform picker/share sheet, interchange purpose, warning displayed). Non-qualifying writes still require the design-document crypto evidence exactly as before.
- **AL2:** Dynamic/static analysis per MASTG-TEST-0001 / MASTG-TEST-0052 is unchanged. Any sensitive artifact found in external storage is traced to its origin; only artifacts reproducible exclusively through a qualifying user-initiated flow are excluded. Artifacts written without explicit user initiation remain findings.
- The four conditions are cumulative and observable in the app's UI flow, so labs do not need developer intent statements to apply them.

## Governance & Consensus

- Intake issue: #397 (opened 2026-07-23, awaiting WG intake validation; suggested labels: `profile:mobile`, `change:modify`, `needs-wg`).
- Consensus plan per CONTRIBUTING.md Stage 2: rough consensus in PR comments; if no sustained objections by **Thursday, August 6, 2026**, the Chair records the decision and merges. If contested, escalate to a `[VOTE]` issue with `stage:wg-vote`.
- Merge lock: requires successful consensus/vote **and** a minimum of two WG member approvals.
- Proposed for the next minor release batch (e.g., `v2.2.0` milestone).

## Checklist

- [x] Linked Issue: Closes #397 
- [x] Requirement Verification section completed
- [x] Governance & Consensus section completed