### PR TITLE
feat(ci): generic Spec ↔ Test Guide consistency lint (AI Tool, MASA, CASA)

### DIFF
--- a/.github/workflows/spec-guide-consistency.yml
+++ b/.github/workflows/spec-guide-consistency.yml
@@ -1,0 +1,39 @@
+name: Spec ↔ Test Guide consistency
+
+# Fails a PR when a Specification and its Test Guide drift apart: a requirement
+# with no test, or a test with no requirement. See scripts/spec-guide-lint.md.
+
+on:
+  pull_request:
+    paths:
+      - 'AI Profile/AI Tool Specification.md'
+      - 'AI Profile/AI Tool Testing Guide.md'
+      - 'MASA/MASA Specification.md'
+      - 'MASA/MASA Test Guide.md'
+      - 'CASA/CASA Specification.md'
+      - 'CASA/CASA Test Guide.md'
+      - 'scripts/spec_guide_lint.py'
+      - 'scripts/spec_guide_lint_baseline.json'
+      - '.github/workflows/spec-guide-consistency.yml'
+  push:
+    branches: [develop]
+    paths:
+      - 'AI Profile/AI Tool Specification.md'
+      - 'AI Profile/AI Tool Testing Guide.md'
+      - 'MASA/MASA Specification.md'
+      - 'MASA/MASA Test Guide.md'
+      - 'CASA/CASA Specification.md'
+      - 'CASA/CASA Test Guide.md'
+      - 'scripts/spec_guide_lint.py'
+      - 'scripts/spec_guide_lint_baseline.json'
+
+jobs:
+  spec-guide-consistency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Lint Spec ↔ Test Guide pairs
+        run: python3 scripts/spec_guide_lint.py

--- a/scripts/spec-guide-lint.md
+++ b/scripts/spec-guide-lint.md
@@ -1,0 +1,68 @@
+# Spec ↔ Test Guide consistency lint
+
+Every ADA profile ships as a **Specification** (defines requirements) paired with a
+**Test Guide** (defines how a lab tests them). They must stay in lockstep.
+`scripts/spec_guide_lint.py` fails CI when a pair drifts:
+
+- a **requirement with no test** in its Guide, or
+- a **test with no requirement** (an orphan / undocumented requirement).
+
+It runs in CI via [`.github/workflows/spec-guide-consistency.yml`](../.github/workflows/spec-guide-consistency.yml)
+on any PR that touches a paired document, and locally with no third-party dependencies.
+
+## Usage
+
+```bash
+python3 scripts/spec_guide_lint.py                 # lint every pair (CI default)
+python3 scripts/spec_guide_lint.py --pair MASA     # one pair
+python3 scripts/spec_guide_lint.py --strict        # ignore the baseline; show ALL debt
+python3 scripts/spec_guide_lint.py --update-baseline
+```
+
+Exit codes: `0` clean (modulo baseline) · `1` new divergence · `2` usage/IO error.
+
+## Pairs covered
+
+| Pair | Spec | Test Guide | Join strategy |
+| --- | --- | --- | --- |
+| MASA | `MASA/MASA Specification.md` | `MASA/MASA Test Guide.md` | **id** — shared `X.Y.Z.W` audit IDs |
+| CASA | `CASA/CASA Specification.md` | `CASA/CASA Test Guide.md` | **id** — shared `N.M.K` audit IDs |
+| AI Tool | `AI Profile/AI Tool Specification.md` | `AI Profile/AI Tool Testing Guide.md` | **title** (bootstrap) |
+
+MASA and CASA already share stable numeric IDs between Spec and Guide, so their join is
+exact. The AI Tool pair numbers the two documents independently, so it is matched on
+**normalized requirement title** as a bootstrap — this is fuzzy and should be upgraded
+(see "Upgrading the AI Tool pair" below).
+
+## How join strategies work
+
+Each pair is a small adapter in `PAIRS` inside `spec_guide_lint.py` — only three things
+vary: the two file paths, a regex that captures the requirement ID (or title) from each
+document, and the strategy (`id` or `title`). Adding a new pair is ~6 lines.
+
+- **`id`** — the capture group is a stable ID present in *both* documents. Robust.
+- **`title`** — the capture group is a human title, normalized (lowercased, punctuation
+  and filler words like "mandatory"/"shall" removed) into a fuzzy key. Fragile to
+  rewording; use only until a shared ID/tag exists.
+
+## The baseline (a ratchet, not a snooze)
+
+Pre-existing drift is recorded in `scripts/spec_guide_lint_baseline.json` so CI blocks
+**new** divergence without being blocked by existing debt. The baseline file *is* the
+debt register — each entry lists the requirement/test label and its line. Burn it down
+as reconciliation lands (issue #400):
+
+1. Add the missing test / fix the mapping in the documents.
+2. Remove the corresponding entry from `spec_guide_lint_baseline.json` (or run
+   `--update-baseline` to regenerate), so the item can never silently regress.
+
+Run `--strict` any time to see the full current debt regardless of the baseline.
+
+## Upgrading the AI Tool pair to `id`
+
+To make the AI Tool pair as robust as MASA/CASA, give each Guide test an explicit,
+machine-readable reference to the Spec requirement it covers — e.g. a line
+`Spec: §6.1.1` (or an HTML comment `<!-- covers: 6.1.1 -->`) under each `## X.Y` test.
+Then change its adapter `strategy` to `id` and point `guide_re` at that tag. This removes
+all fuzzy title-matching. Standardizing that `covers:` convention across every profile
+would let all pairs share one robust code path.

--- a/scripts/spec_guide_lint.py
+++ b/scripts/spec_guide_lint.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Specification <-> Test Guide consistency lint for ADA ASA-WG profiles.
+
+Every ADA profile ships as a *Specification* (defines requirements) paired with a
+*Test Guide* (defines how a lab tests them). The two must stay in lockstep. This
+lint fails when they diverge, i.e. when:
+
+  * a Specification requirement has **no** corresponding test in its Guide, or
+  * a Guide test maps to **no** Specification requirement (an orphan/undocumented
+    requirement).
+
+It is generic across profiles via a small per-pair adapter. Only three things
+vary per pair, so each adapter is a few lines:
+
+  * the file paths of the Spec and the Guide,
+  * how a requirement ID is extracted from each document (a regex), and
+  * the *join strategy*:
+      - "id"    : Spec and Guide share a stable numeric ID (MASA, CASA).
+      - "title" : requirements are matched on normalized title (AI Tool) --
+                  a bootstrap until explicit `covers:` tags are added, at which
+                  point that pair can switch to the far more robust "id" strategy.
+
+Known, already-accepted divergences are recorded in
+`scripts/spec_guide_lint_baseline.json` so CI blocks *new* drift without being
+held hostage by pre-existing debt (a ratchet). Burn the baseline down as the
+reconciliation lands; regenerate it with `--update-baseline`.
+
+Usage:
+  python3 scripts/spec_guide_lint.py                 # lint every pair
+  python3 scripts/spec_guide_lint.py --pair MASA     # one pair
+  python3 scripts/spec_guide_lint.py --strict        # ignore the baseline (report all debt)
+  python3 scripts/spec_guide_lint.py --update-baseline
+
+Exit codes: 0 = clean (modulo baseline) · 1 = new divergence · 2 = usage/IO error.
+No third-party dependencies (standard library only).
+"""
+
+from __future__ import annotations
+import argparse
+import json
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASELINE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             "spec_guide_lint_baseline.json")
+
+# --- Per-pair adapters -------------------------------------------------------
+# spec_re / guide_re: the capture group (1) is the requirement ID for "id"
+# strategy, or the requirement title for "title" strategy.
+PAIRS = {
+    "AI Tool": {
+        "spec": "AI Profile/AI Tool Specification.md",
+        "guide": "AI Profile/AI Tool Testing Guide.md",
+        "strategy": "title",
+        # Spec requirements are `### X.Y.Z Title` (tolerate a trailing `.`/`:`, e.g. `### 1.2.2:` or `### 10.1.1.`)
+        "spec_re": r"^###\s+\d+\.\d+\.\d+[.:]?\s+(.*\S)\s*$",
+        # Guide tests are `## X.Y Title`
+        "guide_re": r"^##\s+\d+\.\d+[.:]?\s+(.*\S)\s*$",
+    },
+    "MASA": {
+        "spec": "MASA/MASA Specification.md",
+        "guide": "MASA/MASA Test Guide.md",
+        "strategy": "id",
+        # Spec audit items are table rows `| X.Y.Z.W | ... |`
+        "spec_re": r"^\|\s*(\d+\.\d+\.\d+\.\d+)\s*\|",
+        # Guide tests are `#### X.Y.Z.W ...`
+        "guide_re": r"^####\s+(\d+\.\d+\.\d+\.\d+)\b",
+    },
+    "CASA": {
+        "spec": "CASA/CASA Specification.md",
+        "guide": "CASA/CASA Test Guide.md",
+        "strategy": "id",
+        # Spec audit items are table rows `| [N.M.K](url) | ... |`
+        "spec_re": r"^\|\s*\[(\d+\.\d+\.\d+)\]",
+        # Guide tests are `### N.M.K ...`
+        "guide_re": r"^###\s+(\d+\.\d+\.\d+)\b",
+    },
+}
+
+_FILLER = re.compile(r"\b(mandatory|ensure|shall|the app)\b")
+
+
+def norm_title(text: str) -> str:
+    """Normalize a requirement title into a fuzzy join key."""
+    t = text.lower()
+    t = re.sub(r"\(duplicate\)", "", t)
+    t = re.sub(r"[^a-z0-9 ]", " ", t)   # drop markdown/punctuation
+    t = _FILLER.sub(" ", t)             # drop filler adjectives that drift
+    return " ".join(t.split())
+
+
+def _read(rel_path: str) -> str:
+    path = os.path.join(ROOT, rel_path)
+    if not os.path.exists(path):
+        print(f"ERROR: file not found: {rel_path}", file=sys.stderr)
+        raise SystemExit(2)
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def extract(rel_path: str, regex: str, strategy: str) -> dict:
+    """Return {join_key: {"label": raw, "line": n}} for a document."""
+    rx = re.compile(regex)
+    out: dict = {}
+    for lineno, line in enumerate(_read(rel_path).splitlines(), 1):
+        m = rx.match(line)
+        if not m:
+            continue
+        raw = m.group(1).strip()
+        key = norm_title(raw) if strategy == "title" else raw
+        if not key:
+            continue
+        out.setdefault(key, {"label": raw, "line": lineno})
+    return out
+
+
+def lint_pair(name: str, cfg: dict) -> dict:
+    spec = extract(cfg["spec"], cfg["spec_re"], cfg["strategy"])
+    guide = extract(cfg["guide"], cfg["guide_re"], cfg["strategy"])
+    untested = {k: spec[k] for k in (set(spec) - set(guide))}   # requirement w/ no test
+    orphans = {k: guide[k] for k in (set(guide) - set(spec))}   # test w/ no requirement
+    return {
+        "spec_count": len(spec),
+        "guide_count": len(guide),
+        "untested": untested,
+        "orphans": orphans,
+    }
+
+
+def load_baseline() -> dict:
+    if not os.path.exists(BASELINE_PATH):
+        return {}
+    with open(BASELINE_PATH, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _baseline_keys(entry: dict, kind: str) -> set:
+    return {row["id"] for row in entry.get(kind, [])}
+
+
+def render(name: str, result: dict, baseline: dict, strict: bool) -> bool:
+    """Print a report for one pair. Return True if it has NEW divergence."""
+    b = baseline.get(name, {})
+    base_untested = set() if strict else _baseline_keys(b, "untested")
+    base_orphans = set() if strict else _baseline_keys(b, "orphans")
+
+    new_untested = {k: v for k, v in result["untested"].items() if k not in base_untested}
+    new_orphans = {k: v for k, v in result["orphans"].items() if k not in base_orphans}
+    n_base = len(result["untested"]) - len(new_untested) + len(result["orphans"]) - len(new_orphans)
+
+    status = "FAIL" if (new_untested or new_orphans) else "ok"
+    print(f"\n[{status}] {name}: {result['spec_count']} requirements / "
+          f"{result['guide_count']} tests"
+          + (f"  ({n_base} known-debt suppressed)" if n_base and not strict else ""))
+
+    if new_untested:
+        print(f"  Requirements with NO test ({len(new_untested)}):")
+        for k, v in sorted(new_untested.items(), key=lambda kv: kv[1]["line"]):
+            print(f"    - {v['label']}   (spec:{v['line']})")
+    if new_orphans:
+        print(f"  Tests with NO matching requirement ({len(new_orphans)}):")
+        for k, v in sorted(new_orphans.items(), key=lambda kv: kv[1]["line"]):
+            print(f"    - {v['label']}   (guide:{v['line']})")
+
+    return bool(new_untested or new_orphans)
+
+
+def build_baseline(names) -> dict:
+    out = {}
+    for name in names:
+        r = lint_pair(name, PAIRS[name])
+        out[name] = {
+            "untested": [{"id": k, "label": v["label"], "spec_line": v["line"]}
+                         for k, v in sorted(r["untested"].items(), key=lambda kv: kv[1]["line"])],
+            "orphans": [{"id": k, "label": v["label"], "guide_line": v["line"]}
+                        for k, v in sorted(r["orphans"].items(), key=lambda kv: kv[1]["line"])],
+        }
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--pair", choices=list(PAIRS), help="lint only this pair")
+    ap.add_argument("--strict", action="store_true",
+                    help="ignore the baseline and report ALL divergence")
+    ap.add_argument("--update-baseline", action="store_true",
+                    help="regenerate the baseline from the current documents")
+    args = ap.parse_args()
+
+    names = [args.pair] if args.pair else list(PAIRS)
+
+    if args.update_baseline:
+        current = load_baseline()
+        current.update(build_baseline(names))
+        with open(BASELINE_PATH, "w", encoding="utf-8") as fh:
+            json.dump(current, fh, indent=2, ensure_ascii=False)
+            fh.write("\n")
+        total = sum(len(v["untested"]) + len(v["orphans"]) for v in current.values())
+        print(f"Wrote baseline for {', '.join(names)} -> {os.path.relpath(BASELINE_PATH, ROOT)} "
+              f"({total} known-debt entries total).")
+        return 0
+
+    baseline = load_baseline()
+    failed = False
+    for name in names:
+        result = lint_pair(name, PAIRS[name])
+        if render(name, result, baseline, args.strict):
+            failed = True
+
+    print()
+    if failed:
+        print("RESULT: FAIL - Spec/Guide divergence introduced. Add the missing test, "
+              "fix the requirement mapping, or (if intentional) update the baseline.")
+        return 1
+    print("RESULT: ok - no new Spec/Guide divergence.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/spec_guide_lint_baseline.json
+++ b/scripts/spec_guide_lint_baseline.json
@@ -1,0 +1,76 @@
+{
+  "AI Tool": {
+    "untested": [
+      {
+        "id": "server side consent backstop for sensitive actions",
+        "label": "Server-Side Consent Backstop for Sensitive Actions",
+        "spec_line": 501
+      },
+      {
+        "id": "exfiltration defense",
+        "label": "Exfiltration Defense",
+        "spec_line": 752
+      },
+      {
+        "id": "no embedded model directed control directives",
+        "label": "No Embedded Model-Directed Control Directives",
+        "spec_line": 796
+      }
+    ],
+    "orphans": [
+      {
+        "id": "explicit consent",
+        "label": "Mandatory Explicit Consent",
+        "guide_line": 659
+      },
+      {
+        "id": "tool function allow listing and parameter validation",
+        "label": "Tool Function Allow-listing and Parameter Validation",
+        "guide_line": 745
+      },
+      {
+        "id": "sensitive output defense in depth",
+        "label": "Sensitive Output Defense in Depth",
+        "guide_line": 933
+      },
+      {
+        "id": "pii detection",
+        "label": "PII Detection",
+        "guide_line": 985
+      },
+      {
+        "id": "output sanitization",
+        "label": "Output Sanitization",
+        "guide_line": 1112
+      },
+      {
+        "id": "maximum response size",
+        "label": "Maximum Response Size",
+        "guide_line": 1241
+      },
+      {
+        "id": "tenant isolation",
+        "label": "Mandatory Tenant Isolation",
+        "guide_line": 1383
+      },
+      {
+        "id": "per user endpoint rate limiting",
+        "label": "Per User Endpoint Rate Limiting",
+        "guide_line": 1615
+      },
+      {
+        "id": "invocation audit trail",
+        "label": "Invocation Audit Trail",
+        "guide_line": 1753
+      }
+    ]
+  },
+  "MASA": {
+    "untested": [],
+    "orphans": []
+  },
+  "CASA": {
+    "untested": [],
+    "orphans": []
+  }
+}


### PR DESCRIPTION
## What

Adds a generic **Specification ↔ Test Guide consistency lint** plus a GitHub Action, covering all three paired profiles: **AI Tool, MASA, CASA**.

It fails a PR when a Spec and its Guide drift apart:
- a **requirement with no test**, or
- a **test with no requirement** (orphan / undocumented requirement).

Files:
- `scripts/spec_guide_lint.py` — stdlib-only engine + per-pair adapters
- `scripts/spec_guide_lint_baseline.json` — accepted pre-existing drift (a ratchet)
- `.github/workflows/spec-guide-consistency.yml` — runs on PRs touching any paired doc
- `scripts/spec-guide-lint.md` — docs

## Why

Addresses **#400** (Tool Spec ↔ Testing Guide have forked). The recent §8.5.1 hash-pinning change (merged in #393) is a live example: the Spec was updated but the Guide's parallel §6.3 was not, producing a contradiction on `develop`. This lint blocks that class of drift automatically.

## How it's generic

Only three things vary per pair (each adapter is ~6 lines): the two file paths, a regex to capture the requirement ID/title from each doc, and a **join strategy**:
- **`id`** — Spec and Guide share a stable numeric ID. **MASA** (`X.Y.Z.W` audit IDs) and **CASA** (`N.M.K` audit IDs) already do this, so their join is exact.
- **`title`** — normalized-title match, used for **AI Tool** as a bootstrap because that pair numbers its two documents independently. Docs explain how to upgrade it to `id` by adding an explicit `covers:` tag to each Guide test.

## Current results

```
[ok]   MASA:    60 requirements / 60 tests      (already in sync)
[ok]   CASA:    55 requirements / 55 tests      (already in sync)
[FAIL] AI Tool: 28 requirements / 34 tests      (12 divergences, baselined)
```

MASA and CASA are **already clean**. The AI Tool pair has **12 baselined debt entries** — the reconciliation worklist for #400:
- **3 requirements with no test:** Server-Side Consent Backstop (§2.1.1), Exfiltration Defense (§5.1.1), **No Embedded Model-Directed Control Directives (§6.1.1)** — the C2 duty.
- **9 orphan tests**, incl. the 7 Guide-only additions (Allow-listing, PII Detection, Output Sanitization, Maximum Response Size, Tenant Isolation, Per-User Rate Limiting, Invocation Audit Trail) plus two **title-drift pairs** (Consent Backstop↔"Mandatory Explicit Consent"; Exfiltration Defense↔"Sensitive Output Defense in Depth").

## Ratchet

Existing drift is recorded in the baseline so CI blocks **new** divergence only. As #400's reconciliation lands, remove entries from `spec_guide_lint_baseline.json` (or `--update-baseline`) so they can never silently regress. `--strict` shows full debt any time.

Verified locally: clean run exits 0; a newly introduced orphan exits 1 flagging only the new item.
