### PR TITLE
fix(AI Profile): No Token Passthrough / Downstream Token Exchange (Tool Spec §1.2.3 + Guide §2.6) — #403

### DIFF
--- a/AI Profile/AI Tool Specification.md
+++ b/AI Profile/AI Tool Specification.md
@@ -296,6 +296,31 @@ If a developer's tool simply trusts a `user_id` passed by the Agent, a compromis
 | Mobile | In Scope |
 | Remote | In Scope |
 
+### 1.2.3 No Token Passthrough / Downstream Token Exchange
+
+#### Description
+
+When an AI Tool calls a downstream or upstream API on the user's behalf, it MUST NOT forward (pass through) the access token it received from the calling client/Agent. Instead, the Tool MUST obtain a separate token scoped to the downstream resource via OAuth 2.0 Token Exchange (RFC 8693) or an equivalent on-behalf-of flow, with the token's audience bound to that resource (RFC 8707 resource indicators). Downstream tokens SHOULD be short-lived and SHOULD be sender-constrained via proof-of-possession (DPoP, RFC 9449); proof-of-possession is REQUIRED for remote, high-value deployments.
+
+#### Rationale
+
+Forwarding the client-supplied token to downstream services is the classic MCP confused-deputy vector: the downstream service cannot tell whether the Tool or the original client is acting, and a token minted for one audience can be replayed against another (audience confusion). Token exchange preserves the user's identity and least-privilege scope while giving each hop an audience-bound credential; proof-of-possession prevents a stolen bearer token from being replayed. This is the most established MCP authorization rule (CoSAI MCP Security §3.2.2).
+
+#### Audit
+
+| Method | Description |
+| :---- | :---- |
+| Static | Review downstream/upstream call construction. Confirm the client-supplied token is never forwarded to another audience, and that a token-exchange (RFC 8693) or equivalent on-behalf-of step mints a downstream-scoped, audience-bound (RFC 8707) token. Confirm downstream tokens are short-lived and, for remote/high-value deployments, sender-constrained (DPoP). |
+| Dynamic | Intercept the Tool's downstream traffic during a tool call. Confirm the token sent downstream is a freshly-exchanged, audience-scoped token — not the client's inbound token and not an over-privileged service-level key. Attempt to replay a captured downstream token against a different audience and confirm it is rejected. |
+
+#### Comments
+
+| Scope | Comment |
+| :---- | :---- |
+| Local | In scope |
+| Mobile | In scope |
+| Remote | In scope |
+
 ## 1.3 Credential Theft/Token Theft
 
 Attackers exploit insecure storage, handling, or transmission of secrets (OAuth tokens, API keys, credentials), enabling impersonation, unauthorized access, or privilege escalation.

--- a/AI Profile/AI Tool Testing Guide.md
+++ b/AI Profile/AI Tool Testing Guide.md
@@ -53,6 +53,8 @@ The App Defense Alliance Application Security Assessment Working Group (ASA WG) 
 
    * [2.5 Tool Function Allow-listing and Parameter Validation](#2.5-tool-function-allow-listing-and-parameter-validation)
 
+   * [2.6 No Token Passthrough / Downstream Token Exchange](#2.6-no-token-passthrough-/-downstream-token-exchange)
+
    * [2.7 Out-of-Band Confirmation for High-Risk Actions](#2.7-out-of-band-confirmation-for-high-risk-actions)
 
 * [3\. Secret Management & Data Protection](#3.-secret-management-&-data-protection)
@@ -198,6 +200,7 @@ Assurance level 0 (self assessment) and Assurance level 1 (Verified Self Assessm
 |  | 2.3 Mandatory Explicit Consent |
 |  | 2.4 Principle of Least Privilege and Scoped Permissions |
 |  | 2.5 Tool Function Allow-listing and Parameter Validation |
+|  | 2.6 No Token Passthrough / Downstream Token Exchange |
 |  | 2.7 Out-of-Band Confirmation for High-Risk Actions |
 | 3\. Secret Management & Data Protection | 3.1 Externalized Secret Management |
 |  | 3.2 Automated PII and Credential Masking in Logs |
@@ -789,6 +792,50 @@ Because AI agents are inherently probabilistic and vulnerable to prompt injectio
 1. **Undeclared Functions:** The server must explicitly reject any invocation of an undeclared function.  
 2. **Parameter Rejection:** The server must successfully reject tool calls containing incorrect parameter types, out-of-range values, or extra parameters.
 
+## 2.6 No Token Passthrough / Downstream Token Exchange
+
+### Description
+
+When the AI Tool calls a downstream/upstream API on the user's behalf, it must not forward the client-supplied token; it must obtain a separate, audience-scoped token via OAuth 2.0 Token Exchange (RFC 8693) or an equivalent on-behalf-of flow, and should sender-constrain downstream tokens (DPoP, RFC 9449) — required for remote/high-value deployments.
+
+### Rationale
+
+Forwarding the inbound token downstream is the classic confused-deputy / audience-confusion vector. Token exchange preserves the user's identity and least-privilege scope while binding each hop's credential to its audience; proof-of-possession stops a stolen bearer token from being replayed.
+
+### Audit
+
+**Evidence**
+
+**AL0, AL1:** Supporting evidence from static inspection of the Tool's downstream/upstream call construction and token-handling code.
+
+**AL2:** Functional AI Tool that performs a downstream call, plus a network interception proxy.
+
+**Test Procedure**
+
+**AL0, AL1:**
+
+1. **No Passthrough:** Review downstream call construction and confirm the client-supplied token is never forwarded to another audience.  
+2. **Token Exchange:** Confirm a token-exchange (RFC 8693) or equivalent on-behalf-of step mints a downstream-scoped, audience-bound (RFC 8707) token.  
+3. **Short-lived / PoP:** Confirm downstream tokens are short-lived and, for remote/high-value deployments, sender-constrained (DPoP).
+
+**AL2:**
+
+1. **Downstream Traffic Inspection:** Trigger a tool call and intercept the Tool's downstream traffic; confirm the token sent downstream is a freshly-exchanged, audience-scoped token — not the client's inbound token and not an over-privileged service key.  
+2. **Replay Across Audience:** Attempt to replay a captured downstream token against a different audience; confirm it is rejected.
+
+**Verification**
+
+**AL0, AL1:**
+
+1. **No Passthrough:** The client-supplied token is never forwarded to a downstream audience.  
+2. **Token Exchange:** Downstream calls use an RFC 8693 (or equivalent OBO) audience-bound token.  
+3. **Short-lived / PoP:** Downstream tokens are short-lived and sender-constrained for remote/high-value deployments.
+
+**AL2:**
+
+1. **Downstream Traffic:** The token observed downstream is a freshly-exchanged, audience-scoped token, not the inbound client token.  
+2. **Replay Across Audience:** A downstream token replayed against a different audience is rejected.
+
 ## 2.7 Out-of-Band Confirmation for High-Risk Actions
 
 ### Description
@@ -830,6 +877,7 @@ Server-side elicitation transits the Agent, so a malicious Agent can fabricate a
 
 1. **Forged Approval Rejected:** The tool must not execute a highest-risk action approved only through the Agent channel.  
 2. **Independent Confirmation Enforced:** The action must execute only after confirmation over the independent channel.
+
 
 # 3. Secret Management & Data Protection
 


### PR DESCRIPTION
## What

Adds the missing MCP token-handling rule to the AI Tool profile (review Finding 4.7), in **both** documents so they stay in sync:

- **AI Tool Specification — new §1.2.3 "No Token Passthrough / Downstream Token Exchange"** (under §1.2 Confused Deputy):
  - **MUST NOT** forward the client-supplied token to downstream/upstream APIs.
  - **MUST** obtain a separate, audience-scoped token via **RFC 8693 token exchange** (or equivalent on-behalf-of), audience-bound per **RFC 8707**.
  - **SHOULD** use short-lived, sender-constrained tokens (**DPoP, RFC 9449**) — **REQUIRED for remote/high-value** deployments.
- **AI Tool Testing Guide — new §2.6** (same title) with AL0/AL1/AL2 evidence, test procedure, and verification (static review of downstream call construction; dynamic downstream-traffic inspection + cross-audience replay).

## Why

Forwarding the inbound token downstream is the classic MCP **confused-deputy / audience-confusion** vector, and it was the single most-established MCP authorization rule missing from the spec (CoSAI MCP Security §3.2.2). Closes **#403**.

## WG alignment

Per @8radree's recommendation on #403 ("add this requirement to the AI Tool Testing guide") plus the agreed direction to state it in both the Spec and the Guide.

## Open decision (flagged, not blocking)

The **DPoP / proof-of-possession level** is drafted as `SHOULD` (→ `MUST` for remote/high-value). This is the tool's *downstream-call* PoP and is **distinct from** the C1 identity wire-format PoP decision in PR #380 (open decision #3). Adjust the level if the WG prefers a blanket `MUST`.

## Verified

Ran the #416 Spec↔Guide consistency lint: AI Tool now **29 requirements / 35 tests**; the new §1.2.3 ↔ §2.6 pair matches (no new divergence; RC=0 against baseline).

Fixes #403.
