### PR TITLE
feat(AI Profile): adaptive red-team testing + defense-in-depth injection criterion (Agent Spec §3.1) — #404

### DIFF
--- a/AI Profile/AI Agent Specification.md
+++ b/AI Profile/AI Agent Specification.md
@@ -161,6 +161,7 @@ The following threat model is significantly based on the CoSAI Agent threat mode
 | Prompt Injection | Causing a model to execute unauthorized commands injected inside a prompt (direct or indirect). | 1.1.2 Jailbreak Resistance Testing |
 |  |  | 3.1.1 Testing for Prompt Injection |
 |  |  | 3.1.2 Testing for Indirect Prompt Injection |
+|  |  | 3.1.3 Adversarial / Red-Team Testing |
 |  |  | 6.2.1 Testing for Tool Description Metadata Sanitization |
 |  |  | 6.2.2 Testing for LLM Control Tokens and Metadata Sanitization |
 | Rogue Actions | Unintended or malicious actions executed by a model-based agent via extensions. | 2.1.1 Testing for Agentic Behavior Limits |
@@ -208,6 +209,7 @@ Model training, protection of model weights and internal hosting infrastructure 
 |  | 2.4 Agent–Tool Interface Conformance | 2.4.1 Verifiable Identity Forwarding |
 | 3. Input/Output Security | 3.1 Input Validation and Sanitization | 3.1.1 Testing for Prompt Injection  (AITG-APP-01) |
 |  |  | 3.1.2 Testing for Indirect Prompt Injection (AITG-APP-02) |
+|  |  | 3.1.3 Adversarial / Red-Team Testing |
 |  | 3.2 Output Validation and Sanitization | 3.2.1 Testing for Unsafe Outputs  (AITG-APP-05) |
 |  |  | 3.2.2 Testing for Prompt Disclosure (AITG-APP-07) |
 |  | 3.3 Orchestrator and Route Integrity | 3.3.1 Testing for Plugin Boundary Violations (AITG-INF-03) |
@@ -489,7 +491,9 @@ Follow the testing procedures outlined in [AITG-APP-01](https://github.com/OWASP
 
 #### Verification
 
-* The model and agent shall prevent overrides of predefined system prompts or executes user-supplied malicious instructions.  
+This control is assessed as resistance to the reference adversary plus layered mitigations, not as a binary guarantee — consistent with §3.1.2, since no current system fully prevents prompt injection.
+
+* The model and agent shall resist attempts to override predefined system prompts or execute user-supplied malicious instructions; residual susceptibility shall be measured as an attack-success rate rather than assumed to be zero.  
 * The model and agent shall not expose sensitive details such as passwords, API keys, or internal configuration information.  
 * The model and agent shall not perform unauthorized or potentially harmful actions.
 
@@ -512,6 +516,26 @@ This control is assessed as **survival against the reference adversary plus the 
 * Poisoned content from the MRT shall not, on its own, cause the Agent to invoke a sensitive action without fresh per-action user consent (§2.2.2).  
 * The Agent shall not reveal confidential information such as passwords, API keys, or other sensitive data in response to injected content.  
 * Indirect-injection attempts and their disposition shall be logged for monitoring (§2.3).
+
+### 3.1.3 Adversarial / Red-Team Testing
+
+#### Evidence
+
+* **Model:** Repeat for each model supported by the Agent.  
+* **Agent:** Agent application, exercised against the ADA Malicious Reference Tool (MRT) for the indirect channel and via the user interface for the direct channel. Developer attestation of a periodic red-team program.
+
+#### Test Procedure
+
+* Beyond the fixed payload sets in §3.1.1 / §3.1.2, conduct a time-boxed **adaptive** adversarial exercise against both the **direct** (user-interface) and **indirect** (tool output, retrieved content, and tool/function descriptions via the MRT) prompt-injection channels, adapting payloads based on the Agent's observed responses.
+* Record the **attack-success rate (ASR)** and the classes of attack attempted.
+* Review the developer's attestation that a periodic red-team program covering prompt injection is in place.
+
+#### Verification
+
+* An adaptive (not solely static-payload) adversarial exercise shall be performed against both the direct and indirect injection channels, and the attack-success rate shall be reported.
+* The Agent's layered mitigations (detection, containment, least-privilege blast-radius limits, and monitoring per §2.3) shall demonstrably reduce attack success relative to an unmitigated baseline.
+* A successful attack shall not, on its own, cause a sensitive action without fresh per-action user consent (§2.2.2) or disclose sensitive data.
+* The developer shall attest to a periodic red-team program covering direct and indirect prompt injection.
 
 ## 3.2 Output Validation and Sanitization
 


### PR DESCRIPTION
## What

Two changes to the AI Agent Specification's §3.1 (Input Validation), addressing review Findings 4.1 and 6.2:

- **New §3.1.3 "Adversarial / Red-Team Testing"** — beyond the fixed AITG payload sets, an AL2 **adaptive** adversarial exercise against **both the direct and indirect** prompt-injection channels, with **attack-success-rate (ASR) reporting** and a developer attestation of a periodic red-team program.
- **Aligned §3.1.1 to defense-in-depth** — replaced the absolute *"shall prevent overrides…"* criterion with a measured, resistance-plus-layered-mitigations posture consistent with §3.1.2 (which already concedes prompt injection has no complete preventive control). Residual susceptibility is now measured as an ASR rather than assumed to be zero.
- Updated the **threat model** (Prompt Injection → also §3.1.3) and the **Controls & Audit Summary** (added §3.1.3).

## Why

- **4.1:** the profile had only static payload lists / fixed benchmarks and no adaptive adversarial exercise; CoSAI maps red teaming to both in-scope personas, AIUC-1 makes it mandatory (B001), and Anthropic reports humans outperform automated systems at novel attacks.
- **6.2:** §3.1.1's absolute "shall prevent" contradicted §3.1.2's own admission that indirect injection can't be fully prevented; the two now share one defense-in-depth philosophy.

## WG alignment

Per @8radree's agreement on #404 ("Red Team testing should be added … a requirement for red team testing of both direct and indirect prompt injection").

Fixes #404.
