### PR TITLE
fix(AI Profile): consent-backstop threat claim + fatigue cross-ref + shown-vs-executed test — #408

### DIFF
--- a/AI Profile/AI Agent Specification.md
+++ b/AI Profile/AI Agent Specification.md
@@ -353,6 +353,8 @@ The Agent shall ensure user approval for any non-reversable actions performed by
 
 Ensuring human-in-the-loop approval mitigates the risk of rogue actions, preventing the agent from autonomously executing destructive or unauthorized commands.
 
+Consent prompting must also be managed to avoid **consent/approval fatigue** — habituation from an excessive volume of prompts that leads users to approve reflexively (the concern deferred from AI Tool Specification §9.2). Because per-action consent for Sensitive Actions necessarily increases prompt frequency, the Agent limits fatigue by (a) reserving mandatory consent for Sensitive Actions rather than routine tool calls, and (b) making each prompt specific and distinguishable — clearly stating the action and its exact parameters — so users can tell consequential requests apart from routine ones. This is a deliberate trade-off: per-action consent is retained for its security value, and fatigue is mitigated by bounding prompt volume and improving prompt quality rather than by weakening the per-action guarantee.
+
 ### 2.2.1 Testing for Over-Reliance on AI (AITG-APP-13)
 
 #### Evidence
@@ -383,13 +385,16 @@ Follow the testing procedures outlined in [AITG-APP-13](https://github.com/OWASP
 * Repeat the same sensitive action and verify consent is requested again — confirming consent is per-action, not granted once at first use.  
 * Perform additional interactions to verify each consent choice is enforced and bound to the operation parameters.  
 *   
-* Perform interaction in which the AI tool requests user consent from the agent.
+* Perform interaction in which the AI tool requests user consent from the agent.  
+* Using the ADA Malicious Reference Tool (MRT) — or a harness that lets the Agent's model dispatch parameters differing from those displayed — drive a Sensitive Action whose consent dialog shows one set of parameters (e.g., recipient `alice@example.com`, amount `$10`) while the Agent attempts to execute a different set (e.g., recipient `attacker@evil.com`, amount `$10,000`). Capture both the parameters presented to the user in the consent prompt and the parameters actually dispatched to the tool (OWASP ASI09 core scenario).
 
 #### Verification
 
 * Verify per-action user consent is requested prior to each invocation of a sensitive action (an operation flagged \`consent\_required\` by the AI Tool). A one-time, first-use consent is not sufficient for sensitive actions.  
 * Verify the consent assertion is bound to the user identity (§2.4) and the operation parameters, and is recorded with a correlation ID for audit (§2.3).  
-* Verify user consent requests made by the AI tool are presented to the user and sent back to the AI Tool.
+* Verify user consent requests made by the AI tool are presented to the user and sent back to the AI Tool.  
+* **Shown-vs-executed fidelity:** Verify that the parameters displayed to the user in the consent prompt are equivalent to the parameters actually executed against the tool. The Agent shall fail closed — aborting and not executing — any Sensitive Action whose executed parameters differ from those the user was shown and approved (OWASP ASI09).  
+* **Consent-fatigue mitigation:** Verify that mandatory consent prompts are reserved for Sensitive Actions (routine, non-sensitive tool calls do not generate consent prompts) and that each prompt is specific and distinguishable rather than generic boilerplate (see §2.2; AI Tool Specification §9.2).
 
 ## 2.3 Agent Observability
 

--- a/AI Profile/AI Tool Specification.md
+++ b/AI Profile/AI Tool Specification.md
@@ -512,7 +512,7 @@ Primary responsibility for presenting, obtaining, and enforcing user consent for
 
 #### Rationale
 
-An AI Tool is invoked by an Agent it cannot fully trust: a confused or compromised Agent may drive a Sensitive Action the user never approved — the confused-deputy case exercised by the ADA Malicious Reference Agent. Consent presentation and enforcement are therefore primarily an Agent/host duty, but the Tool retains a fail-closed backstop so a malicious Agent cannot cause an irreversible action without a user gate. Server-side elicitation is the consent mechanism endorsed for MCP servers (CoSAI MCP Security §3.2.9; OWASP "A Practical Guide for Secure MCP Server Development" §4). User-approval *fatigue* (habituation from excessive prompts) remains an Agent-side concern (see §9.2).
+An AI Tool is invoked by an Agent it cannot fully trust: a confused or benign-but-buggy Agent may omit its own consent step or drive a Sensitive Action the user never approved. Consent presentation and enforcement are therefore primarily an Agent/host duty, but the Tool retains a fail-closed backstop so that an Agent which faithfully relays the Tool's confirmation prompt cannot cause an irreversible action without a user gate. Note the limit of this backstop: server-side elicitation transits the Agent, so a *malicious* Agent can fabricate an affirmative elicitation response without ever presenting it to the user. Elicitation therefore backstops the confused/benign-but-buggy case; it cannot, on its own, defeat a malicious Agent. Defeating a malicious Agent for the highest-risk actions requires confirmation over a channel independent of the Agent (out-of-band confirmation), which is under consideration for a future revision. Server-side elicitation is the consent mechanism endorsed for MCP servers (CoSAI MCP Security §3.2.9; OWASP "A Practical Guide for Secure MCP Server Development" §4). User-approval *fatigue* (habituation from excessive prompts) remains an Agent-side concern (see §9.2 and AI Agent Specification §2.2).
 
 #### Audit
 
@@ -1090,7 +1090,7 @@ Overly permissive tools may expose the user’s data, or result in actions which
 
 Flooding users with excessive consent or permission prompts, causing habituation and leading to blind approval of potentially dangerous or malicious actions.
 
-**Note:** User approval *fatigue* (habituation from an excessive volume of prompts) is out of scope for the AI Tool specification and is addressed in the AI Agent specification. The AI Tool's fail-closed consent backstop for Sensitive Actions is specified in §2.1.1.
+**Note:** User approval *fatigue* (habituation from an excessive volume of prompts) is out of scope for the AI Tool specification because the AI Tool does not own the user-facing consent experience. Because the per-action consent model for Sensitive Actions increases prompt frequency, management of fatigue is an Agent obligation, specified in **AI Agent Specification §2.2 (Agent User Control)**. The AI Tool's fail-closed consent backstop for Sensitive Actions is specified in §2.1.1.
 
 
 # 10 Resource Management/Rate Limiting Absence


### PR DESCRIPTION
Resolves the straightforward parts of review Findings 4.8 + 5.7 (issue #408). Proposed for WG review.

**Fixes (non-normative — rationale/notes/added test bullets; no requirement titles changed, lint-clean):**
1. **Tool Spec §2.1.1 Rationale** — corrected the overclaim that server-side elicitation backstops "a malicious Agent." Since elicitation transits the Agent, a malicious Agent can fabricate the response; the backstop covers the *confused/benign-but-buggy* case only.
2. **Tool Spec §9.2 + Agent Spec §2.2 Rationale** — fixed the broken consent-fatigue cross-reference (Tool deferred fatigue to the Agent Spec, which was silent) and documented the per-action-consent fatigue trade-off.
3. **Agent Spec §2.2.2** — added a **shown-vs-executed parameter-fidelity** test procedure + verification (OWASP ASI09 core scenario: agent follows the protocol while misrepresenting the action) and a fatigue-mitigation verification bullet.

**Held for WG input (not in this PR):**
- **Out-of-band confirmation** for the highest-risk actions as a normative `MUST`/`SHOULD` (§2.1.1) — a design decision (feasibility varies by transport/tool). Noted in the reworded rationale as "under consideration."
- **Risk-tiered consent** (batching lower-risk sensitive actions) vs. the current strict per-action guarantee.

**Notes:** the Interface Contract C3 carries the same "malicious Agent" phrasing and should get the parallel correction in a follow-up. This PR does not touch the `consent_required` dependency in §2.2.2 (that's issue #399).

Fixes #408.