### PR TITLE
fix(AI Profile): reconcile supply-chain deferral (§6.4/§11.2) with §8.5.1 pinning — #418 (straightforward part)

### DIFF
--- a/AI Profile/AI Tool Specification.md
+++ b/AI Profile/AI Tool Specification.md
@@ -865,7 +865,7 @@ Unauthorized, unmonitored, or hidden MCP server instances create blind spots, in
 
 Malicious or compromised MCP servers, dependencies, or packages are introduced into the environment, enabling attackers to execute arbitrary code, exfiltrate data, or persist within the infrastructure.
 
-**Note: This risk is mitigated through the MASA and CASA certification.**
+**Note:** The conventional-security baseline for this threat — ensuring components carry no known exploitable vulnerabilities (CASA 6.1.1) and that the underlying host/platform is hardened — is covered by the MASA and CASA certifications. The AI-specific supply-chain controls that CASA/MASA do **not** provide — strict dependency pinning with hash-based verification, and digital-signature verification of tool packages and model weights — are **in scope for this specification** and are required by §8.5.1 (Resource Pinning and Signature Verification).
 
 # 7 Session and Transport Security Failures
 
@@ -1173,7 +1173,7 @@ Unauthorized, unmonitored, or hidden MCP server instances create blind spots, in
 
 Malicious or compromised MCP servers, dependencies, or packages are introduced into the environment, enabling attackers to execute arbitrary code, exfiltrate data, or persist within the infrastructure.
 
-**Note: This risk is mitigated through the MASA and CASA certification.**
+**Note:** As with §6.4, the conventional-security baseline for this threat (no known exploitable vulnerabilities per CASA 6.1.1, plus host/platform hardening) is covered by the MASA and CASA certifications, while the AI-specific supply-chain controls those certifications do **not** provide — strict dependency pinning with hash-based verification, and digital-signature verification of tool packages and model weights — are in scope and required by §8.5.1 (Resource Pinning and Signature Verification).
 
 # 12 Insufficient Logging, Monitoring, and Auditability
 


### PR DESCRIPTION
Resolves the straightforward part of review Finding 4.10 (issue #418). Proposed for WG review.

**Problem (self-contradiction):** the Tool Spec asserts the whole supply-chain-compromise threat is *"mitigated through the MASA and CASA certification"* (§6.4, §11.2) — i.e., out of profile — yet §8.5.1 mandates in-profile, testable supply-chain controls (hash-based dependency pinning + digital-signature verification), and CASA 6.1.1 only covers known-CVE scanning.

**Fix (Tool Spec, non-title / lint-clean):** reworded both §6.4 and §11.2 deferral Notes to scope the CASA/MASA deferral to the *baseline* (no-known-vulns + host hardening) and explicitly point to the AI-specific controls that are **in scope** via §8.5.1.

**Held for WG input (not in this PR):**
- Which additional CoSAI lifecycle controls to bring in: **decommissioning/revocation** of retired tools (genuine gap), **load-time signature/manifest verification**, **SBOM** as a first-class requirement.
- **Registry/server allowlisting is agent-side** (issue #401), not tool-side — avoid double-specifying.
- Companion consistency fix: the Testing Guide CoSAI-mapping table still marks "Supply Chain Compromise" out-of-scope in two cells; and Guide §6.3 still says "strict version pinning" vs Spec §8.5.1 "hash-based" (also addressed by #417).

**De-dup:** #418 should own supply-chain/lifecycle; **#414** narrows to the mobile-scoping question (per both agents' analysis).

Fixes #418 (straightforward part).