### PR TITLE
fix(CASA): correct/complete ASVS 4.0.3 references in the CASA Test Guide — Fixes #430

### DIFF
--- a/CASA/CASA Test Guide.md
+++ b/CASA/CASA Test Guide.md
@@ -720,7 +720,7 @@ N/A (to be collected by labs)
 
 ---
 ### 2.2.3 Non-revocable stateless authentication tokens must expire within 24 hours of being issued
-External Reference: ASVS Version 4.0.3 Requirement: 3.3.4
+External Reference: ASVS Version 4.0.3 Requirement: 3.3.2
 
 
 **Evidence**
@@ -1321,7 +1321,7 @@ Strong TLS and cipher suites ensure confidentiality and integrity of data in tra
 
 ---
 ### 4.1.1 Application shall enforce the use of TLS for all connections and default to TLS 1.2+. In cases where support for legacy clients is necessary, TLS 1.0 and 1.1 may be supported if mitigations are implemented to minimize the risk of downgrade attacks and known TLS exploits. Regardless of the TLS version in use, the application shall default to secure cipher suites and reject those with known vulnerabilities.
-External Reference: ASVS Version 4.0.3 Requirement: 9.1.2
+External Reference: ASVS Version 4.0.3 Requirement: 9.1.1, 9.1.2, 9.1.3
 
 
 **Evidence**
@@ -1404,7 +1404,7 @@ External Reference: ASVS Version 4.0.3 Requirement: 9.2.1
 
 ---
 ### 4.1.3 No instances of weak cryptography which meaningfully impact the confidentiality or integrity of data.
-External Reference: ASVS Version 4.0.3 Requirement:
+External Reference: ASVS Version 4.0.3 Requirement: 6.2.5
 
 
 **Evidence**
@@ -1972,7 +1972,7 @@ Attackers can perform automated scans to identify vulnerable applications based 
 
 ---
 ### 6.1.1 The application only uses software components without known exploitable vulnerabilities.
-External Reference: ASVS Version 4.0.3 Requirement:
+External Reference: ASVS Version 4.0.3 Requirement: 14.2.1
 
 
 **Evidence**


### PR DESCRIPTION
An adversarial review of **all 48** CASA Test Guide → OWASP **ASVS v4.0.3** references (verified against the ASVS 4.0.3 source document) surfaced 4 clear defects. This PR fixes them.

| CASA req | Before | After | Why |
|---|---|---|---|
| **4.1.3** Weak cryptography | *(missing)* | **6.2.5** | ASVS 6.2.5 = "known insecure block modes (ECB), padding modes, small-block ciphers… not used" — the direct weak-crypto requirement. *(This is the gap reported in #430.)* |
| **6.1.1** Components w/ known vulns | *(missing)* | **14.2.1** | ASVS 14.2.1 = "all components are up to date, preferably using a dependency checker." |
| **4.1.1** TLS | 9.1.2 | **9.1.1, 9.1.2, 9.1.3** | The requirement mandates *TLS for all connections* (9.1.1) **and** *TLS 1.2+* (9.1.3) **and** *strong cipher suites* (9.1.2); it previously cited only the cipher-suite req. |
| **2.2.3** Stateless token expiry | 3.3.4 | **3.3.2** | 3.3.4 is "view/log out of active sessions" — unrelated. 3.3.2 (periodic re-authentication / session-lifetime bound) is the nearest 4.0.3 requirement to a token-lifetime cap. |

**Verified** against the ASVS 4.0.3 document; all other 40 populated references were checked and are correct. CASA Spec↔Guide consistency lint passes.

**Branch note:** applied on `develop`; `main` currently carries the identical references, so these reach `main` at the next release. Happy to also open a direct `main` PR if the release needs it sooner.

**Held for WG decision (NOT in this PR):**
- **3.2.1 / 3.2.2** (secure OAuth flows; `redirect_uri`/`state`): ASVS 4.0.3 has **no** OAuth-specific requirement (added in ASVS 5.0) → recommend labeling as an ADA extension (or mapping 3.2.2 to the nearest 5.1.5/4.2.2).
- **3.1.1** (least privilege): cited 4.1.1 (trusted service layer); the least-privilege concept is 4.1.3 (currently unreferenced) — cite 4.1.3, or both.
- **2.7.6 duplicate**: cited by both 1.3.3 and 1.3.4 — accept as shared, merge, or map 1.3.4→2.2.1.

Fixes #430.