### PR TITLE
feat(AI Profile): MCP elicitation conformance + out-of-band confirmation — #408 (completing PR)

### DIFF
--- a/AI Profile/AI Agent Specification.md
+++ b/AI Profile/AI Agent Specification.md
@@ -191,6 +191,7 @@ The following threat model is significantly based on the CoSAI Agent threat mode
 | Rogue Actions | Unintended or malicious actions executed by a model-based agent via extensions. | 2.1.1 Testing for Agentic Behavior Limits |
 |  |  | 2.1.2 Testing for Sandbox Containment |
 |  |  | 2.2.2 Human in the Loop controls for AI Tools |
+|  |  | 2.2.3 Testing for Tool-Initiated Elicitation Conformance (MCP) |
 | Runaway Agent/Tool Loops | Unbounded or self-reinforcing tool-invocation loops (including tool-to-tool chains) that consume resources without progress and can cascade into failures across integrated components. | 2.1.3 Testing for Loop Termination and Execution Bounds |
 |  |  | 4.1.1 Testing for Resource Exhaustion |
 | Retrieval/Vector Store Poisoning | Malicious modification of retrieval corpora, vector databases, or knowledge bases in RAG systems. | 3.1.2 Testing for Indirect Prompt Injection |
@@ -240,6 +241,7 @@ Model training, protection of model weights and internal hosting infrastructure 
 |  |  | 2.1.3 Testing for Loop Termination and Execution Bounds |
 |  | 2.2 Agent User Control | 2.2.1 Testing for Over-Reliance on AI (AITG-APP-13) |
 |  |  | 2.2.2 Human in the Loop controls for AI Tools |
+|  |  | 2.2.3 Testing for Tool-Initiated Elicitation Conformance (MCP) |
 |  | 2.3 Agent Observability | 2.3.1 Testing for Explainability and Interpretability (AITG-APP-14) |
 |  |  | 2.3.2 Testing for Capability Misuse  (AITG-INF-04) |
 |  | 2.4 Agent–Tool Interface Conformance | 2.4.1 Verifiable Identity Forwarding |
@@ -484,6 +486,8 @@ Ensuring human-in-the-loop approval mitigates the risk of rogue actions, prevent
 
 Consent prompting must also be managed to avoid **consent/approval fatigue** — habituation from an excessive volume of prompts that leads users to approve reflexively (the concern deferred from AI Tool Specification §9.2). Because per-action consent for Sensitive Actions necessarily increases prompt frequency, the Agent limits fatigue by (a) reserving mandatory consent for Sensitive Actions rather than routine tool calls, and (b) making each prompt specific and distinguishable — clearly stating the action and its exact parameters — so users can tell consequential requests apart from routine ones. This is a deliberate trade-off: per-action consent is retained for its security value, and fatigue is mitigated by bounding prompt volume and improving prompt quality rather than by weakening the per-action guarantee.
 
+An alternative fatigue control — **risk-tiered consent**, which batches or suppresses prompts for lower-risk actions — was considered and is **not adopted** for Sensitive Actions in this revision: tiering re-introduces the possibility of a consequential action executing without a fresh, specific approval, which is exactly the guarantee §2.2.2 exists to provide. Developers MAY apply risk tiering to *non-Sensitive* actions (which already require no consent); Sensitive Actions retain the strict per-action gate. This disposition may be revisited if a tiering scheme can be shown to preserve the per-action guarantee for irreversible and high-value actions.
+
 ### 2.2.1 Testing for Over-Reliance on AI (AITG-APP-13)
 
 #### Evidence
@@ -524,6 +528,27 @@ Follow the testing procedures outlined in [AITG-APP-13](https://github.com/OWASP
 * Verify user consent requests made by the AI tool are presented to the user and sent back to the AI Tool.  
 * **Shown-vs-executed fidelity:** Verify that the parameters displayed to the user in the consent prompt are equivalent to the parameters actually executed against the tool. The Agent shall fail closed — aborting and not executing — any Sensitive Action whose executed parameters differ from those the user was shown and approved (OWASP ASI09).  
 * **Consent-fatigue mitigation:** Verify that mandatory consent prompts are reserved for Sensitive Actions (routine, non-sensitive tool calls do not generate consent prompts) and that each prompt is specific and distinguishable rather than generic boilerplate (see §2.2; AI Tool Specification §9.2).
+
+### 2.2.3 Testing for Tool-Initiated Elicitation Conformance (MCP)
+
+#### Evidence
+
+* **Agent** with a human interface, integrated with the ADA Malicious Reference Tool (MRT) or an MCP test server capable of issuing server-initiated elicitation requests.
+
+#### Test Procedure
+
+Using an MCP server (the MRT or equivalent) that issues server-initiated elicitation requests per the Model Context Protocol specification ([Client / Elicitation](https://modelcontextprotocol.io/specification/2026-07-28/client/elicitation)):
+
+* Issue elicitation requests carrying a requested JSON schema for the user-provided content, and observe how the Agent presents and services each one.  
+* Exercise each response action defined by the specification — **accept**, **decline**, and **cancel** — and confirm the Agent returns a well-formed response for each.  
+* Issue an elicitation whose returned content would violate the requested schema, and an elicitation type the Agent does not support, to observe validation, error, and decline handling.
+
+#### Verification
+
+* **Faithful Presentation:** The Agent shall present each elicitation request to the user, accurately reflecting the message and the requested fields; it shall not auto-answer an elicitation without user input.  
+* **Schema-Valid Responses:** Content returned for an accepted elicitation shall validate against the schema requested by the Tool; the Agent shall not return content that violates the requested schema.  
+* **Action Fidelity:** The Agent shall correctly distinguish and return the *accept*, *decline*, and *cancel* actions, and shall not convert a decline or cancel into an affirmative response.  
+* **Safe Handling of Unsupported or Invalid Requests:** Unsupported elicitation types or invalid content shall be declined or errored per the specification, without fabricating a response or leaking internal state.
 
 ## 2.3 Agent Observability
 

--- a/AI Profile/AI Tool Specification.md
+++ b/AI Profile/AI Tool Specification.md
@@ -512,7 +512,7 @@ Primary responsibility for presenting, obtaining, and enforcing user consent for
 
 #### Rationale
 
-An AI Tool is invoked by an Agent it cannot fully trust: a confused or benign-but-buggy Agent may omit its own consent step or drive a Sensitive Action the user never approved. Consent presentation and enforcement are therefore primarily an Agent/host duty, but the Tool retains a fail-closed backstop so that an Agent which faithfully relays the Tool's confirmation prompt cannot cause an irreversible action without a user gate. Note the limit of this backstop: server-side elicitation transits the Agent, so a *malicious* Agent can fabricate an affirmative elicitation response without ever presenting it to the user. Elicitation therefore backstops the confused/benign-but-buggy case; it cannot, on its own, defeat a malicious Agent. Defeating a malicious Agent for the highest-risk actions requires confirmation over a channel independent of the Agent (out-of-band confirmation), which is under consideration for a future revision. Server-side elicitation is the consent mechanism endorsed for MCP servers (CoSAI MCP Security §3.2.9; OWASP "A Practical Guide for Secure MCP Server Development" §4). User-approval *fatigue* (habituation from excessive prompts) remains an Agent-side concern (see §9.2 and AI Agent Specification §2.2).
+An AI Tool is invoked by an Agent it cannot fully trust: a confused or benign-but-buggy Agent may omit its own consent step or drive a Sensitive Action the user never approved. Consent presentation and enforcement are therefore primarily an Agent/host duty, but the Tool retains a fail-closed backstop so that an Agent which faithfully relays the Tool's confirmation prompt cannot cause an irreversible action without a user gate. Note the limit of this backstop: server-side elicitation transits the Agent, so a *malicious* Agent can fabricate an affirmative elicitation response without ever presenting it to the user. Elicitation therefore backstops the confused/benign-but-buggy case; it cannot, on its own, defeat a malicious Agent. Defeating a malicious Agent for the highest-risk actions requires confirmation over a channel independent of the Agent (out-of-band confirmation), which is under consideration for a future revision. Server-side elicitation is defined by the Model Context Protocol specification ([MCP — Client / Elicitation](https://modelcontextprotocol.io/specification/2026-07-28/client/elicitation)) and is the consent mechanism endorsed for MCP servers by secure-design guidance (CoSAI MCP Security; OWASP "A Practical Guide for Secure MCP Server Development"). User-approval *fatigue* (habituation from excessive prompts) remains an Agent-side concern (see §9.2 and AI Agent Specification §2.2).
 
 #### Audit
 
@@ -520,6 +520,31 @@ An AI Tool is invoked by an Agent it cannot fully trust: a confused or benign-bu
 | :---- | :---- |
 | Static | Identify operations that qualify as Sensitive Actions. Verify the Tool mandates a server-side elicitation/confirmation (or enforces non-disableable client confirmation) before executing them, and does not execute a Sensitive Action solely on an Agent-supplied "consent obtained" claim. Verify confirmation messages state the action's implications. |
 | Dynamic | Using the ADA Malicious Reference Agent (or equivalent), attempt to trigger a Sensitive Action with forged or absent consent. Verify the Tool requests confirmation via elicitation or fails closed, and does not execute the action. |
+
+#### Comments
+
+| Scope | Comment |
+| :---- | :---- |
+| Local | In scope |
+| Mobile | In scope |
+| Remote | In scope |
+
+### 2.1.2 Out-of-Band Confirmation for High-Risk Actions
+
+#### Description
+
+Because server-side elicitation transits the Agent (§2.1.1), it cannot, on its own, defeat a *malicious* Agent that fabricates an affirmative response. For the **highest-risk** operations — irreversible actions, transfers of value or money, or the granting/expansion of access — the AI Tool SHOULD require confirmation over a channel that is **independent of the Agent** (out-of-band), such that user approval cannot be forged by the Agent in the request path. For **remote** and other high-value deployments this out-of-band confirmation is REQUIRED. Examples include a confirmation link or one-time code delivered to a pre-registered user channel (email, SMS, authenticator/push), or a provider-hosted approval page authenticated directly to the user. Where out-of-band confirmation is not feasible for a given action, the Tool MUST fall back to the §2.1.1 server-side elicitation backstop and MUST NOT silently downgrade to Agent-relayed consent.
+
+#### Rationale
+
+The §2.1.1 backstop closes the confused / benign-but-buggy Agent case; it does not close the malicious-Agent case, because both the confirmation prompt and its response pass through the Agent. An independent channel breaks that assumption: the user confirms the specific action directly with the resource owner or Tool, so a malicious Agent cannot manufacture consent for an irreversible or high-value action. Gating this at the highest risk tier keeps the added friction proportionate and bounds consent-prompt volume (see AI Agent Specification §2.2 on approval fatigue).
+
+#### Audit
+
+| Method | Description |
+| :---- | :---- |
+| Static | Identify the highest-risk operations (irreversible, value transfer, access grant/expansion). Verify the Tool defines an out-of-band confirmation path independent of the Agent request channel for them (REQUIRED for remote/high-value deployments), and that when out-of-band confirmation is unavailable it fails closed to the §2.1.1 elicitation backstop rather than to Agent-relayed consent. |
+| Dynamic | Using the ADA Malicious Reference Agent (or equivalent), attempt to approve a highest-risk action entirely through the Agent channel, including forging an elicitation response. Verify the action does not execute without confirmation delivered and returned over the independent channel. |
 
 #### Comments
 

--- a/AI Profile/AI Tool Testing Guide.md
+++ b/AI Profile/AI Tool Testing Guide.md
@@ -53,6 +53,8 @@ The App Defense Alliance Application Security Assessment Working Group (ASA WG) 
 
    * [2.5 Tool Function Allow-listing and Parameter Validation](#2.5-tool-function-allow-listing-and-parameter-validation)
 
+   * [2.7 Out-of-Band Confirmation for High-Risk Actions](#2.7-out-of-band-confirmation-for-high-risk-actions)
+
 * [3\. Secret Management & Data Protection](#3.-secret-management-&-data-protection)
 
    * [3.1 Externalized Secret Management](#3.1-externalized-secret-management)
@@ -196,6 +198,7 @@ Assurance level 0 (self assessment) and Assurance level 1 (Verified Self Assessm
 |  | 2.3 Mandatory Explicit Consent |
 |  | 2.4 Principle of Least Privilege and Scoped Permissions |
 |  | 2.5 Tool Function Allow-listing and Parameter Validation |
+|  | 2.7 Out-of-Band Confirmation for High-Risk Actions |
 | 3\. Secret Management & Data Protection | 3.1 Externalized Secret Management |
 |  | 3.2 Automated PII and Credential Masking in Logs |
 |  | 3.3 Secure Session Tokens |
@@ -785,6 +788,48 @@ Because AI agents are inherently probabilistic and vulnerable to prompt injectio
 
 1. **Undeclared Functions:** The server must explicitly reject any invocation of an undeclared function.  
 2. **Parameter Rejection:** The server must successfully reject tool calls containing incorrect parameter types, out-of-range values, or extra parameters.
+
+## 2.7 Out-of-Band Confirmation for High-Risk Actions
+
+### Description
+
+For the highest-risk operations — irreversible actions, transfers of value or money, or the granting/expansion of access — the AI Tool SHOULD require user confirmation over a channel independent of the AI Agent (out-of-band), so that approval cannot be forged by the Agent in the request path. Out-of-band confirmation is REQUIRED for remote and other high-value deployments. Where it is not feasible for a given action, the Tool MUST fall back to the server-side elicitation backstop (§2.3) and MUST NOT downgrade to Agent-relayed consent.
+
+### Rationale
+
+Server-side elicitation transits the Agent, so a malicious Agent can fabricate an affirmative response without ever showing the user. An independent confirmation channel — for example a link or one-time code delivered to a pre-registered email/SMS/authenticator, or a provider-hosted approval page authenticated directly to the user — lets the user approve the specific action directly, closing the malicious-Agent gap for the actions where a forged approval is most costly.
+
+### Audit
+
+**Evidence**
+
+**AL0, AL1:** Supporting evidence from static code inspection identifying the highest-risk operations and the out-of-band confirmation path defined for them.
+
+**AL2:** Functional AI Tool exposing at least one highest-risk action, plus the ADA Malicious Reference Agent (or equivalent) able to forge Agent-channel responses.
+
+**Test Procedure**
+
+**AL0, AL1:**
+
+1. **Classify High-Risk Operations:** Review the tool's operations and confirm that irreversible, value-transferring, and access-granting actions are identified as highest-risk.  
+2. **Review Confirmation Channel:** Verify the code routes confirmation for those actions to a channel independent of the Agent request path (REQUIRED for remote/high-value deployments), and that it fails closed to §2.3 elicitation rather than to Agent-relayed consent when out-of-band confirmation is unavailable.
+
+**AL2:**
+
+1. **Forge Agent-Channel Approval:** Using the Malicious Reference Agent, attempt to approve a highest-risk action entirely through the Agent channel, including fabricating an elicitation response.  
+2. **Verify Independent Confirmation:** Confirm the action does not execute until confirmation is delivered and returned over the independent channel.
+
+**Verification**
+
+**AL0, AL1:**
+
+1. **High-Risk Classification:** The highest-risk operations must be explicitly identified.  
+2. **Independent Channel:** Confirmation for those operations must be routed over a channel independent of the Agent (REQUIRED for remote/high-value deployments), with a fail-closed fallback to §2.3 rather than Agent-relayed consent.
+
+**AL2:**
+
+1. **Forged Approval Rejected:** The tool must not execute a highest-risk action approved only through the Agent channel.  
+2. **Independent Confirmation Enforced:** The action must execute only after confirmation over the independent channel.
 
 # 3. Secret Management & Data Protection
 


### PR DESCRIPTION
## 🔗 Linked Issue
Fixes #408 (completes it — #426 handled the straightforward parts).

## 📖 Summary of Changes

Completes #408, stacked on **#426** (which reworded the §2.1.1 backstop threat claim, fixed the fatigue cross-reference, and added the shown-vs-executed test). Addresses @8radree's comment on the issue plus the held normative items.

**Per @8radree's comment:**
- **Agent Spec §2.2.3 — Testing for Tool-Initiated Elicitation Conformance (MCP).** New agent-side test verifying the Agent faithfully presents, schema-validates, and round-trips the `accept` / `decline` / `cancel` responses of MCP server-initiated elicitation, and safely handles unsupported/invalid requests. References the canonical [MCP Client / Elicitation spec](https://modelcontextprotocol.io/specification/2026-07-28/client/elicitation). *("add test cases on the agent … verify that the agent can perform each of the elicitation requests from the MCP per the MCP specification.")*
- **Tool Spec §2.1.1 reference fix.** Corrected the elicitation citation to point at the canonical **MCP specification** (Client/Elicitation) as the primary source, keeping CoSAI/OWASP as endorsing guidance. *("the tool reference may be pointing to the wrong specification.")*

**Held items now completed:**
- **Tool Spec §2.1.2 — Out-of-Band Confirmation for High-Risk Actions** (normative): for the highest-risk/irreversible actions the Tool **SHOULD** require confirmation over a channel independent of the Agent — **REQUIRED** for remote/high-value deployments — with a fail-closed fallback to §2.1.1. Added the **title-matched** Tool Testing Guide **§2.7** test (+ TOC + Specification Summary).
- **Risk-tiered consent** explicitly dispositioned in Agent Spec §2.2 rationale: **not adopted** for Sensitive Actions (it would erode the per-action guarantee); MAY apply to non-Sensitive actions.

## ✅ Verification
Ran the #416 Spec ↔ Test Guide consistency lint — **RC=0, no new divergence** (AI Tool: 29 requirements / 35 tests; new §2.1.2 ↔ §2.7 pair matches).

## 🔗 Dependencies / sequencing
- **Stacked on #426** (base branch `fix/consent-backstop-fatigue`); this diff shows only the new parts.
- The new Testing Guide test is numbered **§2.7** to avoid colliding with **#419**'s pending §2.6. If #419 does not land, renumber to §2.6 on merge (cosmetic; the lint matches by title, not number).

## 📋 Requirement Verification
- [x] The proposed requirement text matches the approved Issue.
- [x] All automated tests/checks pass on the `develop` branch. (Spec↔Guide lint RC=0)

## ⚖️ Governance & Consensus
- [ ] **Consensus Reached:** The Working Group has reached a rough consensus on this change.
- [ ] **Voting:** If required, the formal vote has passed (Link to vote results: [URL]).
- [ ] **Reviewers:** At least two members of the Working Group have signed off on this PR.

## 📸 Additional Context

**Open decisions (non-blocking):**
- **Out-of-band level:** drafted as `SHOULD` → `MUST` for remote/high-value (mirrors #419's DPoP pattern). Adjust to a blanket `MUST` if the WG prefers.
- **CoSAI/OWASP sections:** the precise `§3.2.9` / `§4` pointers were dropped in favor of document-level citations pending confirmation of the exact sections; re-add if verified.
- The Agent–Tool Interface Contract (C3) carries the same "malicious Agent" phrasing and out-of-band angle; a parallel note there can follow up.
